### PR TITLE
This addresses a number of documentation issues:

### DIFF
--- a/sphinx-docs/development/development_setup.md
+++ b/sphinx-docs/development/development_setup.md
@@ -1,63 +1,115 @@
 # Setting up the Development Environment
 
 ## Prerequisites
+
 - Git
 - Python (version 3.10 or later)
 - Poetry (Python dependency management tool)
 
 ## Cloning the Repository
+
 1. Open your terminal or command prompt.
 2. Navigate to the directory where you want to clone the repository.
 3. Run the following command to clone the repository:
-git clone https://github.com/username/maeser.git
 
+   `git clone https://github.com/username/maeser.git`
 
 Replace `https://github.com/username/maeser.git` with the actual URL of the repository.
+
+- **Can this be updated to `https://github.com/byu-cpe/maeser.git` now?**
+
+## Create a Virtual Environment
+
+It is highly recommended that you use a python virtual environment for your system to ensure you have total control over the installed software versions. There are two main virtual environment approaches, each with their own adherents and each with its own operational methods.
+
+### Virtual Environments: Conda
+
+1. You can install Conda using:
+
+```
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+bash ~/miniconda.sh -b -p $HOME/miniconda
+```
+
+Note that for Mac OS X, replacing Linux with MacOSX will do the trick.
+
+2. Next, you can make a new virtual environment with a specific version of python with the following:
+
+`conda create --name maeser python=3.10 pip`
+
+3. Finally, you activate the virtual environment with:
+
+`conda activate maeser`
+
+and you deactivate it with:
+
+`conda deactivate`
+
+### Virtual Environments: venv
+
+1. You create a new venv with the following. Make sure you are in the Maeser directory when you do it. Also, note that the version of python that will be installed into the venv will be whatever python you run to create the venv. As a result, you may have to install a specific python on your machine to get what you want.
+
+`python3 -m venv .`
+
+2. Next, you activate the virtual environment with:
+
+`source ./bin/activate`
+
+and you deactivate it with:
+
+`deactivate`
 
 ## Installing Dependencies
 
 ### If you're developing Maeser itself
-1. Change to the cloned directory:
-cd maeser
 
+1. Change to the cloned directory:
+
+`cd Maeser`
 
 2. Install the project in editable mode using pip:
-pip install -e .
 
+`pip install -e .`
 
 This will install Maeser in a way that allows you to make changes to the source code and have them reflected immediately.
 
 ### If you're creating an application that uses Maeser
+
 1. Change to the cloned directory:
-cd maeser
 
+`cd Maeser`
 
-2. Install the project dependencies using Poetry:
-poetry install
+2. Install poetry itself if you haven't previously done so:
 
+`curl -sSL https://install.python-poetry.org | python3 -`
 
-3. Install the Maeser package from the `dist` directory:
+3. Then, install the project dependencies:
 
-pip install dist/maeser*.tar.gz
+`poetry install`
 
+3. Install the Maeser package from the `dist` directory: **This doesn't work.**
+
+`pip install dist/maeser\*.tar.gz`
 
 This will install the latest version of Maeser from the local distribution package.
 
 ## Running Tests
+
 After installing the dependencies, you can run the test suite to ensure everything is working correctly:
 
-pytest tests/
-
+`pytest tests`
 
 ## Building Documentation
+
 If you're working on the project documentation, you can build it locally using Sphinx:
 
-cd docs/
-make html
+`cd sphinx-docs`
 
+`make html`
 
-This will generate the HTML documentation in the `docs/_build/html` directory.
+This will generate the HTML documentation in the `sphinx-docs/_build/html` directory.
 
 ## Additional Steps
+
 - Set up any required environment variables or configuration files.
 - Refer to the project's README or contributing guidelines for more information on development workflows, coding standards, and other relevant details.


### PR DESCRIPTION
#31 it tells them how to use a virtual environment for their work (recommended)

#28  it tells them build docs in sphinx-docs instead of docs

#27 it tells them how to install poetry

#26 it puts in a comment asking the question if we can use the real repo name now?

#25 it fixes a couple of places where it says maeser when it should be Maeser