### PR TITLE
Further modified the examples documentation:

### DIFF
--- a/sphinx-docs/development/example.md
+++ b/sphinx-docs/development/example.md
@@ -16,7 +16,7 @@ The example program sets up a Flask web application with two different chat bran
 
 ## Key Components
 
-### 1. Chat Management
+### Chat Management
 
 ```python
 from maeser.chat.chat_logs import ChatLogsManager
@@ -28,7 +28,7 @@ sessions_manager = ChatSessionManager(chat_logs_manager=chat_logs_manager)
 
 These lines initialize the chat logs and session managers, which handle storing and managing chat conversations.
 
-### 2. Prompt Definition
+### Prompt Definition
 
 ```python
 maeser_prompt: str = """You are speaking from the perspective of Karl G. Maeser.
@@ -48,7 +48,7 @@ byu_prompt: str = """You are speaking about the history of Brigham Young Univers
 
 Here, we define system prompts for two different chat branches. These prompts set the context and behavior for the AI in each branch.
 
-### 3. RAG (Retrieval-Augmented Generation) Setup
+### RAG (Retrieval-Augmented Generation) Setup
 
 ```python
 from maeser.graphs.simple_rag import get_simple_rag
@@ -64,7 +64,7 @@ This section sets up two RAG graphs, one for each chat branch, and registers the
 
 > **NOTE:** The `get_simple_rag` function could be replaced with any LangGraph compiled state graph. So, for a custom application, you will likely want to create a custom graph and register it with the sessions manager. For more instructions on creating custom graphs, see [Using Custom Graphs](./graphs.md)
 
-### 4. User Management and Authentication
+### User Management and Authentication
 
 For the example, we register a `GithubAuthenticator` with our `UserManager`. This means that our application will use Github OAuth to authenticate users in the application. This will require you to register a GithHub OAuth Application.
 
@@ -109,7 +109,7 @@ Before you can run the app you need to register it.
 
 Here, we set up user management with GitHub authentication and implement rate limiting (5 requests updated every 60 seconds).
 
-### 5. Flask Application Setup
+### Flask Application Setup
 
 ```python
 from flask import Flask
@@ -142,7 +142,19 @@ python example/example.py
 
 This should start up a local server. Opening a web browser to the address it tells will bring up the example app. Authenticating with Github should then bring up the main page where you can either ask questions about Karl G. Maeser or about BYU.
 
-## Changing the Port
+## Customization
+
+You can customize various aspects of the application, such as:
+
+- Changing the port the server runs on
+- Changing or removing the authentication method(s)
+- Adding more chat branches
+- Modifying the rate limiting parameters
+- Updating the app name, chat head, logo, or favicon
+
+Here, we discuss a few of these.
+
+### Changing the Port
 
 You may want to change the port the server runs on. For example,
 on Mac OSX, port 5000 (the default above) is not available for use. For Mac, you will need to change it to another port, such as 3000. Here are the steps to do so:
@@ -165,14 +177,33 @@ if __name__ == "__main__":
     app.run(port=3000)
 ```
 
-## Customization
+### Removing the Authentication Method
 
-You can customize various aspects of the application, such as:
+Two changes are required to remove the authentication method:
 
-- Adding more chat branches
-- Changing the authentication method(s)
-- Modifying the rate limiting parameters
-- Updating the app name, chat head, logo, or favicon
+1. Comment or remove the following three lines of code in example.py:
+
+   ```python
+   #github_authenticator = GithubAuthenticator("<your client ID>", "<your client secret>", "http://localhost:5000/login/github_callback")
+   #user_manager = UserManager("chat_logs/users", max_requests=5, rate_limit_interval=60)
+   #user_manager.register_authenticator("github", github_authenticator)
+   ```
+
+2. In the Flask instantiation, provide `None` in place of the `user_manager` parameter:
+
+```python
+app: Flask = add_flask_blueprint(
+    base_app,
+    "secret",
+    sessions_manager,
+    None,  # This is the change
+    app_name="Test App",
+    chat_head="/static/Karl_G_Maeser.png",
+    # Note that you can change other images too! We stick with the defaults for the logo and favicon.
+    # main_logo_light="/static/main_logo_light.png",
+    # favicon="/static/favicon.png",
+)
+```
 
 ## Conclusion
 

--- a/sphinx-docs/index.rst
+++ b/sphinx-docs/index.rst
@@ -14,6 +14,7 @@ Welcome to Maeser's documentation!
    autodoc/maeser/modules.rst
 
 .. toctree ::
+   :numbered:
    :maxdepth: 1
    :caption: Development:
 


### PR DESCRIPTION
1. Added section numbering to the index.rst file - I think the docs' organization is so much easier to understand with numbering rather than relying on heading text size.  This is especially true in a large, multi-part document.

2. Added instructions on removing authentication  from example.py