### PR TITLE
Fix logging tokens and cost for individual logs and combined log data

### DIFF
--- a/maeser/chat/chat_logs.py
+++ b/maeser/chat/chat_logs.py
@@ -31,7 +31,9 @@ import platform
 
 
 class BaseChatLogsManager(ABC):
-    def __init__(self, chat_log_path: str, user_manager: UserManager | None = None) -> None:
+    def __init__(
+        self, chat_log_path: str, user_manager: UserManager | None = None
+    ) -> None:
         """
         Initializes the BaseChatLogsManager.
 
@@ -62,7 +64,9 @@ class BaseChatLogsManager(ABC):
         pass
 
     @abstractmethod
-    def log_feedback(self, branch_name: str, session_id: str, message_index: int, feedback: str) -> None:
+    def log_feedback(
+        self, branch_name: str, session_id: str, message_index: int, feedback: str
+    ) -> None:
         """
         Abstract method to log feedback for a message.
 
@@ -96,7 +100,9 @@ class BaseChatLogsManager(ABC):
         pass
 
     @abstractmethod
-    def get_chat_logs_overview(self, sort_by: str, order: str, branch_filter: str, feedback_filter: str) -> tuple[list[dict], int, float]:
+    def get_chat_logs_overview(
+        self, sort_by: str, order: str, branch_filter: str, feedback_filter: str
+    ) -> tuple[list[dict], int, float]:
         """
         Abstract method to get an overview of chat logs.
 
@@ -192,11 +198,13 @@ class ChatLogsManager(BaseChatLogsManager):
             None
         """
         if not self._does_log_exist(branch_name, session_id):
-            self._create_log_file(branch_name, session_id, log_data.get('user', None))
+            self._create_log_file(branch_name, session_id, log_data.get("user", None))
         else:
             self._update_log_file(branch_name, session_id, log_data)
 
-    def log_feedback(self, branch_name: str, session_id: str, message_index: int, feedback: str) -> None:
+    def log_feedback(
+        self, branch_name: str, session_id: str, message_index: int, feedback: str
+    ) -> None:
         """
         Adds feedback to the log for a specific response in a specific session.
 
@@ -209,11 +217,15 @@ class ChatLogsManager(BaseChatLogsManager):
         Returns:
             None
         """
-        with open(f'{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log', 'r') as file:
+        with open(
+            f"{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log", "r"
+        ) as file:
             log: dict = yaml.safe_load(file)
-            log['messages'][message_index]['liked'] = feedback
+            log["messages"][message_index]["liked"] = feedback
 
-        with open(f'{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log', 'w') as file:
+        with open(
+            f"{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log", "w"
+        ) as file:
             yaml.dump(log, file)
 
     def get_chat_history_overview(self, user: User | None) -> list[dict]:
@@ -229,23 +241,27 @@ class ChatLogsManager(BaseChatLogsManager):
         overview = []
         conversations = self._get_file_list()
         for conversation in conversations:
-            current_user_name: str = 'anon' if user is None else user.full_id_name
-            if current_user_name == conversation['user']:
-                overview.append({
-                    'branch': conversation['branch'],
-                    'session': conversation['name'].removesuffix('.log'),
-                    'modified': conversation['modified'],
-                    'header': conversation['first_message']
-                })
+            current_user_name: str = "anon" if user is None else user.full_id_name
+            if current_user_name == conversation["user"]:
+                overview.append(
+                    {
+                        "branch": conversation["branch"],
+                        "session": conversation["name"].removesuffix(".log"),
+                        "modified": conversation["modified"],
+                        "header": conversation["first_message"],
+                    }
+                )
         # Sort conversations by date modified
-        overview.sort(key=lambda x: x['modified'], reverse=True)
+        overview.sort(key=lambda x: x["modified"], reverse=True)
 
         # Remove conversations with no first message
-        overview = [link for link in overview if link['header'] is not None]
+        overview = [link for link in overview if link["header"] is not None]
 
         return overview
 
-    def get_chat_logs_overview(self, sort_by: str, order: str, branch_filter: str, feedback_filter: str) -> tuple[list[dict], int, float]:
+    def get_chat_logs_overview(
+        self, sort_by: str, order: str, branch_filter: str, feedback_filter: str
+    ) -> tuple[list[dict], int, float]:
         """
         Gets an overview of chat logs.
 
@@ -264,23 +280,40 @@ class ChatLogsManager(BaseChatLogsManager):
         log_files = self._get_file_list()
 
         if branch_filter:
-            log_files = [f for f in log_files if branch_filter.lower() in f['branch'].lower()]
+            log_files = [
+                f for f in log_files if branch_filter.lower() in f["branch"].lower()
+            ]
 
         if feedback_filter:
-            feedback_filter_bool = feedback_filter.lower() == 'true'
-            log_files = [f for f in log_files if f['has_feedback'] == feedback_filter_bool]
+            feedback_filter_bool = feedback_filter.lower() == "true"
+            log_files = [
+                f for f in log_files if f["has_feedback"] == feedback_filter_bool
+            ]
 
-        reverse = (order == 'desc')
+        reverse = order == "desc"
         log_files.sort(key=lambda x: x[sort_by], reverse=reverse)
 
         # Calculate aggregate number of tokens and cost
         total_tokens = 0
         total_cost = 0.0
         for file in log_files:
-            with open(f'{self.chat_log_path}/chat_history/{file["branch"]}/{file["name"]}', 'r') as f:
+            with open(
+                f'{self.chat_log_path}/chat_history/{file["branch"]}/{file["name"]}',
+                "r",
+            ) as f:
                 log = yaml.safe_load(f)
-                total_tokens += log.get('tokens', 0)
-                total_cost += log.get('cost', 0.0)
+                if log.get("total_tokens") is None:
+                    print(
+                        f"\x1b[33mWarning: \"total_tokens\" key is missing from log for file {file['name']}, defaulting value to 0.\x1b[0m"
+                    )
+                else:
+                    total_tokens += log.get("total_tokens", 0)
+                if log.get("total_cost") is None:
+                    print(
+                        f"\x1b[33mWarning: \"total_cost\" key is missing from log for file {file['name']}, defaulting value to 0.\x1b[0m"
+                    )
+                else:
+                    total_cost += log.get("total_cost", 0.0)
 
         return log_files, total_tokens, total_cost
 
@@ -295,7 +328,9 @@ class ChatLogsManager(BaseChatLogsManager):
         Returns:
             dict: The chat history for the session.
         """
-        with open(f'{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log', 'r') as file:
+        with open(
+            f"{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log", "r"
+        ) as file:
             chat_history = yaml.safe_load(file)
         return chat_history
 
@@ -310,40 +345,43 @@ class ChatLogsManager(BaseChatLogsManager):
         Returns:
             str: The rendered template for the log file.
         """
+
         def process_messages(messages: dict) -> dict:
             """
             Process each system response in the conversation and convert it to HTML.
 
             Args:
                 filename (str): The name of the log file.
-            
+
             Returns:
                 dict: The processed messages in HTML format.
             """
             for message in messages:
-                message['content'] = get_response_html(message['content'])
-            
+                message["content"] = get_response_html(message["content"])
+
             return messages
 
         try:
-            print(f'{self.chat_log_path}/chat_history/{branch}/{filename}')
-            with open(f'{self.chat_log_path}/chat_history/{branch}/{filename}', 'r') as file:
+            print(f"{self.chat_log_path}/chat_history/{branch}/{filename}")
+            with open(
+                f"{self.chat_log_path}/chat_history/{branch}/{filename}", "r"
+            ) as file:
                 content = yaml.safe_load(file)
-            
-            user_name = content['user']
-            real_name = content['real_name']
-            branch = content['branch']
-            time = content['time']
-            total_cost = round(content['total_cost'], 3)
-            total_tokens = content['total_tokens']
-            
+
+            user_name = content["user"]
+            real_name = content["real_name"]
+            branch = content["branch"]
+            time = content["time"]
+            total_cost = round(content["total_cost"], 3)
+            total_tokens = content["total_tokens"]
+
             try:
-                messages = process_messages(content['messages'])
+                messages = process_messages(content["messages"])
             except KeyError:
                 messages = None
-            
+
             return render_template(
-                'display_chat_log.html',
+                "display_chat_log.html",
                 user_name=user_name,
                 real_name=real_name,
                 branch=branch,
@@ -351,12 +389,12 @@ class ChatLogsManager(BaseChatLogsManager):
                 total_cost=total_cost,
                 total_tokens=total_tokens,
                 messages=messages,
-                app_name=branch
+                app_name=branch,
             )
         except FileNotFoundError:
-            abort(404, description='Log file not found')
+            abort(404, description="Log file not found")
         except yaml.YAMLError as e:
-            abort(500, description=f'Error parsing log file: {e}')
+            abort(500, description=f"Error parsing log file: {e}")
 
     def save_feedback(self, feedback: dict) -> None:
         """
@@ -364,25 +402,25 @@ class ChatLogsManager(BaseChatLogsManager):
 
         Args:
             feedback (dict): The feedback to save.
-            
+
         Returns:
             None
         """
 
         # Make directory if it doesn't exist
         try:
-            mkdir(f'{self.chat_log_path}/feedback')
+            mkdir(f"{self.chat_log_path}/feedback")
         except FileExistsError:
             pass
 
         now = time.time()
-        timestamp = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime(now))
-        filename = f'{self.chat_log_path}/feedback/{timestamp}.log'
+        timestamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime(now))
+        filename = f"{self.chat_log_path}/feedback/{timestamp}.log"
 
-        with open(filename, 'w') as f:
+        with open(filename, "w") as f:
             yaml.dump(feedback, f)
 
-        print(f'Feedback saved to {filename}')
+        print(f"Feedback saved to {filename}")
 
     def save_training_data(self, training_data: dict) -> None:
         """
@@ -394,18 +432,18 @@ class ChatLogsManager(BaseChatLogsManager):
 
         # Make directory if it doesn't exist
         try:
-            mkdir(f'{self.chat_log_path}/training_data')
+            mkdir(f"{self.chat_log_path}/training_data")
         except FileExistsError:
             pass
 
         now = time.time()
-        timestamp = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime(now))
-        filename = f'{self.chat_log_path}/training_data/{timestamp}.log'
+        timestamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime(now))
+        filename = f"{self.chat_log_path}/training_data/{timestamp}.log"
 
-        with open(filename, 'w') as f:
+        with open(filename, "w") as f:
             yaml.dump(training_data, f)
 
-        print(f'Training data saved to {filename}')
+        print(f"Training data saved to {filename}")
 
     def _get_file_list(self) -> list[dict]:
         """
@@ -414,21 +452,26 @@ class ChatLogsManager(BaseChatLogsManager):
         Returns:
             bool: True if the log file exists, False otherwise.
         """
+
         def get_creation_time(file_path):
-            if platform.system() == 'Darwin':  # macOS
-                result = subprocess.run(['stat', '-f', '%B', file_path], capture_output=True, text=True)
+            if platform.system() == "Darwin":  # macOS
+                result = subprocess.run(
+                    ["stat", "-f", "%B", file_path], capture_output=True, text=True
+                )
                 if result.returncode != 0:
                     raise RuntimeError(f"Error getting creation time: {result.stderr}")
                 return int(result.stdout.strip())
-            elif platform.system() == 'Linux':
-                result = subprocess.run(['stat', '-c', '%W', file_path], capture_output=True, text=True)
+            elif platform.system() == "Linux":
+                result = subprocess.run(
+                    ["stat", "-c", "%W", file_path], capture_output=True, text=True
+                )
                 if result.returncode != 0:
                     raise RuntimeError(f"Error getting creation time: {result.stderr}")
                 return int(result.stdout.strip())
             else:
                 # Fallback for other operating systems
                 return int(path.getctime(file_path))
-        
+
         def get_file_info(file_path: str) -> dict:
             """
             Get detailed information from a file and return it as a dictionary.
@@ -439,26 +482,33 @@ class ChatLogsManager(BaseChatLogsManager):
             Returns:
                 dict: A dictionary containing detailed information about the file.
             """
+
             def has_feedback(msgs: list) -> bool:
                 for msg in msgs:
-                    if 'liked' in msg:
+                    if "liked" in msg:
                         return True
                 return False
-            
+
             file_info = {}
             try:
-                with open(file_path, 'r') as file:
+                with open(file_path, "r") as file:
                     chat_log = yaml.safe_load(file)
-                    file_info['has_feedback'] = has_feedback(chat_log.get('messages', []))
-                    file_info['first_message'] = chat_log.get('messages', [{}])[0]["content"] if len(chat_log.get('messages', [])) > 0 else None
-                    file_info['user'] = chat_log.get('user', 'unknown user')
-                    file_info['real_name'] = chat_log.get('real_name', 'Student')
+                    file_info["has_feedback"] = has_feedback(
+                        chat_log.get("messages", [])
+                    )
+                    file_info["first_message"] = (
+                        chat_log.get("messages", [{}])[0]["content"]
+                        if len(chat_log.get("messages", [])) > 0
+                        else None
+                    )
+                    file_info["user"] = chat_log.get("user", "unknown user")
+                    file_info["real_name"] = chat_log.get("real_name", "Student")
             except Exception as e:
                 print(f"Error: Cannot read file {file_path}: {e}")
             return file_info
 
         file_list = []
-        for root, dirs, files in walk(self.chat_log_path + '/chat_history'):
+        for root, dirs, files in walk(self.chat_log_path + "/chat_history"):
             for file_name in files:
                 file_path = path.join(root, file_name)
                 if path.isfile(file_path):  # Check if the path is a file
@@ -467,20 +517,24 @@ class ChatLogsManager(BaseChatLogsManager):
                     except RuntimeError:
                         # Fallback if stat doesn't work at all (may show modified time)
                         created_time = int(path.getctime(file_path))
-                    
+
                     file_stat = stat(file_path)
                     file_info = {
-                        'name': file_name,
-                        'created': created_time,
-                        'modified': file_stat.st_mtime,
-                        'branch': path.basename(root),  # Get the branch name from the directory
+                        "name": file_name,
+                        "created": created_time,
+                        "modified": file_stat.st_mtime,
+                        "branch": path.basename(
+                            root
+                        ),  # Get the branch name from the directory
                     }
                     # Update file_info with additional details from get_file_info
                     file_info.update(get_file_info(file_path))
                     file_list.append(file_info)
         return file_list
 
-    def _create_log_file(self, branch_name: str, session_id: str, user: User | None = None) -> None:
+    def _create_log_file(
+        self, branch_name: str, session_id: str, user: User | None = None
+    ) -> None:
         """
         Creates a new log file for a chat session.
 
@@ -501,7 +555,7 @@ class ChatLogsManager(BaseChatLogsManager):
             "branch": branch_name,
             "total_cost": 0,
             "total_tokens": 0,
-            "messages": []
+            "messages": [],
         }
 
         # ensure log directory exists
@@ -509,43 +563,61 @@ class ChatLogsManager(BaseChatLogsManager):
             makedirs(f"{self.chat_log_path}/chat_history/{branch_name}")
 
         # create log file
-        with open(f"{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log", "w") as file:
+        with open(
+            f"{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log", "w"
+        ) as file:
             yaml.dump(log_info, file)
 
-    def _update_log_file(self, branch_name: str, session_id: str, log_data: dict) -> None:
+    def _update_log_file(
+        self, branch_name: str, session_id: str, log_data: dict
+    ) -> None:
         """
         Updates the log file with the new log data.
 
         Args:
             branch_name (str): The name of the branch.
             session_id (str): The session ID for the conversation.
-            log_data (dict): The data to be logged. Should contain the following keys: "user_info", "cost", "tokens", and "message".
-        
+            log_data (dict): The data to be logged. Should contain the following keys: "user_info", "cost", "tokens_used", and "message".
+
         Returns:
             None
         """
-        with open(f"{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log", "r") as file:
+        with open(
+            f"{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log", "r"
+        ) as file:
             log: dict = yaml.safe_load(file)
 
             log["messages"] = log.get("messages", [])
+
+            # Add user message
             log["messages"].append(
                 {
                     "role": "user",
                     "content": log_data["messages"][-2],
-                })
-            log["messages"].append({
+                }
+            )
+
+            # Add chatbot message and execution stats
+            log["messages"].append(
+                {
                     "role": "system",
                     "content": log_data["messages"][-1],
-                    "context": [context.page_content for context in log_data["retrieved_context"]],
+                    "context": [
+                        context.page_content
+                        for context in log_data["retrieved_context"]
+                    ],
                     "execution_time": log_data.get("execution_time", 0),
-                    "tokens_used": log_data.get("tokens", 0),
-                    "cost": log_data.get("cost", 0)
-                })
-            
-            log["total_cost"] += log_data.get("cost", 0)
-            log["total_tokens"] += log_data.get("tokens", 0)
+                    "tokens_used": log_data.get("tokens_used", 0),
+                    "cost": log_data.get("cost", 0),
+                }
+            )
 
-        with open(f"{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log", "w") as file:
+            log["total_cost"] += log_data.get("cost", 0)
+            log["total_tokens"] += log_data.get("tokens_used", 0)
+
+        with open(
+            f"{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log", "w"
+        ) as file:
             yaml.dump(log, file)
 
     def _does_log_exist(self, branch_name: str, session_id: str) -> bool:
@@ -554,8 +626,10 @@ class ChatLogsManager(BaseChatLogsManager):
 
         Args:
             session_id (str): The session ID to check for.
-        
+
         Returns:
             bool: True if the log file exists, False otherwise.
         """
-        return path.exists(f"{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log")
+        return path.exists(
+            f"{self.chat_log_path}/chat_history/{branch_name}/{session_id}.log"
+        )

--- a/tests/chat/test_chat_logs.py
+++ b/tests/chat/test_chat_logs.py
@@ -22,23 +22,30 @@ from langchain_core.documents import Document
 from maeser.chat.chat_logs import ChatLogsManager
 from maeser.user_manager import User
 
+
 @pytest.fixture
 def chat_logs_manager(tmp_path):
     return ChatLogsManager(str(tmp_path))
+
 
 @pytest.fixture
 def mock_user():
     return User("test_user")
 
+
 @pytest.fixture
 def test_log_data():
     return {
         "messages": ["Test message", "Another test message"],
-        "retrieved_context": [Document("Test document"), Document("Another test document")],
+        "retrieved_context": [
+            Document("Test document"),
+            Document("Another test document"),
+        ],
         "execution_time": 1.5,
-        "tokens": 100,
-        "cost": 0.002
+        "tokens_used": 100,
+        "cost": 0.002,
     }
+
 
 @pytest.fixture
 def create_test_log(chat_logs_manager, mock_user):
@@ -46,13 +53,17 @@ def create_test_log(chat_logs_manager, mock_user):
         chat_logs_manager._create_log_file(branch_name, session_id, mock_user)
         if log_data:
             chat_logs_manager._update_log_file(branch_name, session_id, log_data)
+
     return _create_log
+
 
 def test_create_log_file(chat_logs_manager, mock_user, create_test_log):
     branch_name, session_id = "test_branch", "test_session"
     create_test_log(branch_name, session_id)
 
-    log_path = f"{chat_logs_manager.chat_log_path}/chat_history/{branch_name}/{session_id}.log"
+    log_path = (
+        f"{chat_logs_manager.chat_log_path}/chat_history/{branch_name}/{session_id}.log"
+    )
     assert os.path.exists(log_path)
 
     with open(log_path, "r") as file:
@@ -66,12 +77,14 @@ def test_create_log_file(chat_logs_manager, mock_user, create_test_log):
     assert log_content["total_tokens"] == 0
     assert log_content["messages"] == []
 
+
 def test_does_log_exist(chat_logs_manager, create_test_log):
     branch_name, session_id = "test_branch", "test_session"
     assert not chat_logs_manager._does_log_exist(branch_name, session_id)
 
     create_test_log(branch_name, session_id)
     assert chat_logs_manager._does_log_exist(branch_name, session_id)
+
 
 def test_log(chat_logs_manager, mock_user, test_log_data):
     branch_name, session_id = "test_branch", "test_session"
@@ -80,7 +93,9 @@ def test_log(chat_logs_manager, mock_user, test_log_data):
     chat_logs_manager.log(branch_name, session_id, initial_log_data)
     chat_logs_manager.log(branch_name, session_id, test_log_data)
 
-    log_path = f"{chat_logs_manager.chat_log_path}/chat_history/{branch_name}/{session_id}.log"
+    log_path = (
+        f"{chat_logs_manager.chat_log_path}/chat_history/{branch_name}/{session_id}.log"
+    )
     assert os.path.exists(log_path)
 
     with open(log_path, "r") as file:
@@ -93,12 +108,14 @@ def test_log(chat_logs_manager, mock_user, test_log_data):
     assert log_content["total_cost"] == 0.002
     assert log_content["total_tokens"] == 100
 
+
 def test_log_feedback_invalid_index(chat_logs_manager, create_test_log, test_log_data):
     branch_name, session_id = "test_branch", "test_session"
     create_test_log(branch_name, session_id, test_log_data)
 
     with pytest.raises(IndexError):
         chat_logs_manager.log_feedback(branch_name, session_id, 5, True)
+
 
 def test_get_chat_history(chat_logs_manager, create_test_log, test_log_data):
     branch_name, session_id = "test_branch", "test_session"
@@ -114,9 +131,11 @@ def test_get_chat_history(chat_logs_manager, create_test_log, test_log_data):
     assert chat_history["total_cost"] == 0.002
     assert chat_history["total_tokens"] == 100
 
+
 def test_get_chat_history_nonexistent(chat_logs_manager):
     with pytest.raises(FileNotFoundError):
         chat_logs_manager.get_chat_history("nonexistent_branch", "nonexistent_session")
+
 
 def _read_log_file(chat_logs_manager, branch_name, session_id):
     log_path = f"{chat_logs_manager.chat_log_path}/{branch_name}/{session_id}.log"


### PR DESCRIPTION
chat_logs.py was attempting to access tokens and cost data using incorrect key names in a few areas (e.g. it was attempting to get log["tokens"] instead of log["total_tokens"], etc.), which caused total tokens and cost data to be lost both within the individual chat logs and the collective log overview. This commit renames the incorrect key names to the correct ones and adds some light debugging.