### PR TITLE
Pipeline-filepath-config

### DIFF
--- a/example/flask_example.py
+++ b/example/flask_example.py
@@ -55,13 +55,13 @@ sessions_manager.register_branch(branch_name="byu", branch_label="BYU History", 
 # One for the history of BYU and one for the life of Karl G. Maeser.
 # Ensure that topics are all lower case and spaces between words
 vectorstore_config = {
-    "byu history": "example/vectorstores/byu",      # Vectorstore for BYU history.
-    "karl g maeser": "example/vectorstores/maeser"  # Vectorstore for Karl G. Maeser.
+    "byu history": f"{VEC_STORE_PATH}/byu",      # Vectorstore for BYU history.
+    "karl g maeser": f"{VEC_STORE_PATH}/maeser"  # Vectorstore for Karl G. Maeser.
 }
 
 byu_maeser_pipeline_rag: CompiledGraph = get_pipeline_rag(
     vectorstore_config=vectorstore_config, 
-    memory_filepath="chat_logs/pipeline_memory.db",
+    memory_filepath=f"{LOG_SOURCE_PATH}/pipeline_memory.db",
         api_key=OPENAI_API_KEY, 
         system_prompt_text=(
             "You are speaking from the perspective of Karl G. Maeser."

--- a/example/flask_example_user_mangement.py
+++ b/example/flask_example_user_mangement.py
@@ -63,13 +63,13 @@ sessions_manager.register_branch(branch_name="byu", branch_label="BYU History", 
 # One for the history of BYU and one for the life of Karl G. Maeser.
 # Ensure that topics are all lower case and spaces between words
 vectorstore_config = {
-    "byu history": "example/vectorstores/byu",      # Vectorstore for BYU history.
-    "karl g maeser": "example/vectorstores/maeser"  # Vectorstore for Karl G. Maeser.
+    "byu history": f"{VEC_STORE_PATH}/byu",      # Vectorstore for BYU history.
+    "karl g maeser": f"{VEC_STORE_PATH}/maeser"  # Vectorstore for Karl G. Maeser.
 }
 
 byu_maeser_pipeline_rag: CompiledGraph = get_pipeline_rag(
     vectorstore_config=vectorstore_config, 
-    memory_filepath="chat_logs/pipeline_memory.db",
+    memory_filepath=f"{LOG_SOURCE_PATH}/pipeline_memory.db",
         api_key=OPENAI_API_KEY, 
         system_prompt_text=(
             "You are speaking from the perspective of Karl G. Maeser."

--- a/example/terminal_example.py
+++ b/example/terminal_example.py
@@ -54,13 +54,13 @@ sessions_manager.register_branch(branch_name="byu", branch_label="BYU History", 
 # One for the history of BYU and one for the life of Karl G. Maeser.
 # Ensure that topics are all lower case and spaces between words
 vectorstore_config = {
-    "byu history": "example/vectorstores/byu",      # Vectorstore for BYU history.
-    "karl g maeser": "example/vectorstores/maeser"  # Vectorstore for Karl G. Maeser.
+    "byu history": f"{VEC_STORE_PATH}/byu",      # Vectorstore for BYU history.
+    "karl g maeser": f"{VEC_STORE_PATH}/maeser"  # Vectorstore for Karl G. Maeser.
 }
 
 byu_maeser_pipeline_rag: CompiledGraph = get_pipeline_rag(
     vectorstore_config=vectorstore_config, 
-    memory_filepath="chat_logs/pipeline_memory.db",
+    memory_filepath=f"{LOG_SOURCE_PATH}/pipeline_memory.db",
         api_key=OPENAI_API_KEY, 
         system_prompt_text=(
             "You are speaking from the perspective of Karl G. Maeser."


### PR DESCRIPTION
The filepaths for the vectorstores and memory  in the pipeline rag were hard-coded directories. This PR replaces those filepaths to be assigned based on the filepaths set in config_example.yaml