### PR TITLE
Fix `make setup`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@
 .PHONY: setup test testVerbose clean_venv
 
 PYTHON := python3
-PIP := $(VENV)/bin/pip
 VENV := .venv
+PIP := $(VENV)/bin/pip
 POETRY := $(VENV)/bin/poetry
 PYTEST := $(VENV)/bin/pytest
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PYTEST := $(VENV)/bin/pytest
 setup:
 	$(PIP) install poetry
 	@echo "Updating poetry lock file if necessary..."
-	$(POETRY) lock --no-update
+	$(POETRY) lock
 	$(POETRY) install
 	$(PIP) install -e .
 	pytest tests

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,14 @@ PIP := $(VENV)/bin/pip
 POETRY := $(VENV)/bin/poetry
 PYTEST := $(VENV)/bin/pytest
 
-setup:
+setup: $(VENV)/bin/activate
 	$(PIP) install poetry
 	@echo "Updating poetry lock file if necessary..."
 	$(POETRY) lock
 	$(POETRY) install
 	$(PIP) install -e .
-	pytest tests
+	@echo "Maeser setup complete. Running pytests..."
+	. $(VENV)/bin/activate && pytest tests
 
 clean_venv:
 	@echo "Removing existing virtual environment if it exists..."


### PR DESCRIPTION
This PR fixes the errors of `make setup` by reordering the declaration of variables and removing an incorrect poetry option.