### PR TITLE
Fix Mermaid diagrams not rendering properly in dark theme in the Documentation

### DIFF
--- a/sphinx-docs/_static/mermaid-theme-switch.js
+++ b/sphinx-docs/_static/mermaid-theme-switch.js
@@ -1,0 +1,7 @@
+// This small javascript code fixes Mermaid diagrams not rendering properly in dark or light mode
+document.addEventListener("DOMContentLoaded", () => {
+  const theme = document.documentElement.getAttribute("data-theme") === "dark"
+    ? "dark"
+    : "default";
+  mermaid.initialize({ startOnLoad: true, theme });
+});

--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -121,3 +121,9 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# Add all javascript files to be used in the documentation pages
+html_js_files = [
+    "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js", # Mermaid diagrams
+    "mermaid-theme-switch.js", # Allows mermaid diagrams to render properly based on current theme
+]


### PR DESCRIPTION
This PR fixes mermaid diagrams not rendering properly by adding javascript to detect the current page theme and updating mermaid diagrams accordingly.