### PR TITLE
Fix Autodoc Build Errors

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Sphinx build
         run: |
           cd sphinx-docs
-          make html
+          SPHINXOPTS="-W" make html
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Sphinx build
         run: |
           cd sphinx-docs
-          SPHINXOPTS="-W" make html
+          SPHINXOPTS="-W" make html # The -W flag throws all warnings as errors
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -55,7 +55,8 @@ autodoc_mock_imports = [
     'flask',
     'flask-login',
     'flask_login',
-    'pytest'
+    'pytest',
+    'ldap3',
 ]
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
The Documentation github action builds the sphinx docs for Maeser, but the autodoc was silently failing due to the `ldap3` module not being included in `autodoc_mock_imports` within `conf.py`. This PR fixes the autodoc issue by adding `ldap3` to this list of imports. This PR also alters the Documentation GitHub action to fail if any warnings are thrown during the Sphinx build step to make sure these issues don't go unnoticed in the future.