### PR TITLE
Save pipeline memory into log source path instead of vectorstore path

### DIFF
--- a/example/flask_pipeline_example.py
+++ b/example/flask_pipeline_example.py
@@ -52,7 +52,7 @@ vectorstore_config = {
 
 byu_maeser_pipeline_rag: CompiledGraph = get_pipeline_rag(
     vectorstore_config=vectorstore_config, 
-    memory_filepath=f"{VEC_STORE_PATH}/pipeline_memory.db",
+    memory_filepath=f"{LOG_SOURCE_PATH}/pipeline_memory.db",
     api_key=OPENAI_API_KEY, 
     system_prompt_text=(pipeline_prompt),
     model=LLM_MODEL_NAME)


### PR DESCRIPTION
`flask_pipeline_example.py` was incorrectly configured to store the memory for the pipeline branch in the vectorstore directory instead of the chat logs directory. This PR fixes this issue.