### PR TITLE
Add action to only allow pre_release branch to be pulled into main

### DIFF
--- a/.github/workflows/pull_from_pre_release.yml
+++ b/.github/workflows/pull_from_pre_release.yml
@@ -1,0 +1,28 @@
+# 'Extract Branch Name' step based on aborilov's Stack Overflow answer here: https://stackoverflow.com/a/58035262/14797164
+
+name: Require PR into main from pre_release
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  require-pre-release-branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract Branch Name
+        run: |
+            branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+            echo "branch=$branch" >> $GITHUB_OUTPUT
+            echo PR started from \'$branch\' branch.
+        id: extract_branch
+      - name: Confirm that PR is from pre_release branch
+        run: |
+            if [ "${{ steps.extract_branch.outputs.branch }}" == "pre_release" ]; then
+                echo "PR is from the correct branch; pass."
+            else
+                echo "::error ::This PR must come from the 'pre_release' branch in order to merge into main."
+                exit 1
+            fi


### PR DESCRIPTION
This PR introduces a GitHub action that will only run when PRs are made toward the main branch. It only passes if the PR is coming from the pre_release branch, ensuring accidental PRs into main aren't made.