### PR TITLE
Fix: correct option order for setting permissions in deployment guide

### DIFF
--- a/sphinx-docs/sysadmin/deployment.md
+++ b/sphinx-docs/sysadmin/deployment.md
@@ -100,7 +100,7 @@ sudo setfacl -R -m u:www-data:rwx /path/to/maeser/app
 ```
 
 ```bash
-sudo setfacl -R -m -d u:www-data:rwx /path/to/maeser/app
+sudo setfacl -R -d -m u:www-data:rwx /path/to/maeser/app
 ```
 
 The first command grants read-write-execute permissions for `www-data` for every file in your project directory. The second command sets these permissions as the default for files created in this directory in the future, so these commands only need to be run once.


### PR DESCRIPTION
The updated deployment guide has instructions for setting default rwx permission, but it had the `-d` and `-m` options in the wrong order:

```bash
sudo setfacl -R --m d u:www-data:rwx /path/to/maeser/app
```

This PR corrects the order of these operations:

```bash
sudo setfacl -R -d -m u:www-data:rwx /path/to/maeser/app
```