### PR TITLE
generate_response tweaks

### DIFF
--- a/dynamic_implementations/generate_response.py
+++ b/dynamic_implementations/generate_response.py
@@ -23,7 +23,7 @@ import time # For ngrok delay and main thread loop
 # Import Maeser components
 from maeser.chat.chat_logs import ChatLogsManager
 from maeser.chat.chat_session_manager import ChatSessionManager
-from maeser.graphs.universal_rag import get_pipeline_rag
+from maeser.graphs.universal_rag import get_universal_rag
 from langgraph.graph.graph import CompiledGraph
 
 # Import configuration
@@ -47,7 +47,7 @@ global_maeser_sessions = {}
 
 # --- Utility Functions (shared by all bot handlers) ---
 
-def parse_vectorstores_from_bot_txt(path):
+def parse_data_from_bot_txt(path):
     """Parses a bot config file to extract rules and datasets."""
     sections = {}
     current_header = None
@@ -81,6 +81,46 @@ def get_valid_course_ids():
         if os.path.isdir(os.path.join(BOT_DATA_PATH, name))
     ]
 
+def register_branch(branch_name:str, course_id:str, bot_config_path:str):
+    """Registers a branch to the session handler.
+
+    Args:
+        branch_name (str): The name to give the branch.
+        course_id (str): The ID for the course to be registered. This should match the name of the course's vectorstore directory
+        bot_config_path (str): The path to `bot.txt` for the course's chatbot.
+    """
+    parsed_data = parse_data_from_bot_txt(bot_config_path)
+    
+    # Ensure required keys exist in parsed data
+    if "rules" not in parsed_data or "datasets" not in parsed_data:
+        return f"Error: 'rules' or 'datasets' section missing in bot.txt for course '{course_id}'."
+
+    rules = parsed_data["rules"]
+    datasets = parsed_data["datasets"]
+    if isinstance(datasets, str):
+        datasets = [datasets]
+
+    vectorstore_config = {
+        dataset: os.path.join(VEC_STORE_PATH, course_id, dataset) for dataset in datasets
+    }
+    ruleset = "\n".join(rules) + "\n{context}\n"
+
+    universal_rag: CompiledGraph = get_universal_rag(
+        vectorstore_config=vectorstore_config,
+        memory_filepath=f"{LOG_SOURCE_PATH}/universal_memory_{course_id}.db",
+        api_key=OPENAI_API_KEY,
+        system_prompt_text=ruleset,
+        model=LLM_MODEL_NAME
+    )
+
+    sessions_manager.register_branch(
+        branch_name=branch_name,
+        branch_label=f"Universal-{course_id}",
+        graph=universal_rag
+    )
+    print(f"Registered Maeser bot branch for course: {course_id}")
+
+
 # --- Main Chat Handling Function (Unified Logic) ---
 
 def handle_message(user_id: str, course_id: str, message_text: str) -> str:
@@ -93,40 +133,11 @@ def handle_message(user_id: str, course_id: str, message_text: str) -> str:
     if not os.path.exists(bot_config_path):
         return f"Bot config for course '{course_id}' not found. Please ensure the course ID is valid and configured."
     
-    branch_name = f"pipeline_{course_id}"
+    branch_name = f"universal_{course_id}"
 
     # Register the Maeser bot branch if it hasn't been registered yet
     if branch_name not in sessions_manager.branches:
-        parsed_data = parse_vectorstores_from_bot_txt(bot_config_path)
-        
-        # Ensure required keys exist in parsed data
-        if "rules" not in parsed_data or "datasets" not in parsed_data:
-            return f"Error: 'rules' or 'datasets' section missing in bot.txt for course '{course_id}'."
-
-        rules = parsed_data["rules"]
-        datasets = parsed_data["datasets"]
-        if isinstance(datasets, str):
-            datasets = [datasets]
-
-        vectorstore_config = {
-            dataset: os.path.join(VEC_STORE_PATH, course_id, dataset) for dataset in datasets
-        }
-        ruleset = "\n".join(rules) + "\n{context}\n"
-
-        pipeline_rag: CompiledGraph = get_pipeline_rag(
-            vectorstore_config=vectorstore_config,
-            memory_filepath=f"{LOG_SOURCE_PATH}/pipeline_memory_{course_id}.db",
-            api_key=OPENAI_API_KEY,
-            system_prompt_text=ruleset,
-            model=LLM_MODEL_NAME
-        )
-
-        sessions_manager.register_branch(
-            branch_name=branch_name,
-            branch_label=f"Universal-{course_id}",
-            graph=pipeline_rag
-        )
-        print(f"Registered Maeser bot branch for course: {course_id}")
+        register_branch(branch_name, course_id, bot_config_path)
 
     # Get or create a Maeser session for the unique user+course combination
     session_key = f"{user_id}:{course_id}"

--- a/dynamic_implementations/generate_response.py
+++ b/dynamic_implementations/generate_response.py
@@ -16,9 +16,6 @@ Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import os
-import threading
-import asyncio # Needed for running Discord bot client
-import time # For ngrok delay and main thread loop
 
 # Import Maeser components
 from maeser.chat.chat_logs import ChatLogsManager
@@ -28,7 +25,7 @@ from langgraph.graph.graph import CompiledGraph
 
 # Import configuration
 from config import (
-    LOG_SOURCE_PATH, OPENAI_API_KEY, VEC_STORE_PATH, CHAT_HISTORY_PATH, LLM_MODEL_NAME, DISCORD_BOT_TOKEN
+    LOG_SOURCE_PATH, OPENAI_API_KEY, VEC_STORE_PATH, CHAT_HISTORY_PATH, LLM_MODEL_NAME
 )
 
 # Set API key

--- a/maeser/graphs/universal_rag.py
+++ b/maeser/graphs/universal_rag.py
@@ -41,7 +41,7 @@ def format_topic_keys(topics: Dict[str, str]) -> str:
     else:
         return ", ".join(f"'{key}'" for key in keys[:-1]) + f", or '{keys[-1]}'"
 
-def get_pipeline_rag(vectorstore_config: Dict[str, str], memory_filepath: str, api_key: str | None = None, system_prompt_text: str = 'You are a helpful teacher helping a student with course material.\nYou will answer a question based on the context provided:\nDon\'t answer questions about other things.\n\n{context}\n', model: str = 'gpt-4o-mini') -> CompiledGraph:
+def get_universal_rag(vectorstore_config: Dict[str, str], memory_filepath: str, api_key: str | None = None, system_prompt_text: str = 'You are a helpful teacher helping a student with course material.\nYou will answer a question based on the context provided:\nDon\'t answer questions about other things.\n\n{context}\n', model: str = 'gpt-4o-mini') -> CompiledGraph:
     retrievers = {
 
         topic: FAISS.load_local(


### PR DESCRIPTION
This PR makes the following tweaks:

- Rename get_pipeline_rag function in universal_rag.py to get_universal_rag
- Refactor bot registration logic in generate_response.py
- Rename parse_vectorstores_from_bot_txt function to parse_data_from_bot_txt for clarity