### PR TITLE
Remove Excessive Copyright

### DIFF
--- a/.github/Makefile
+++ b/.github/Makefile
@@ -1,18 +1,3 @@
-# © 2024
-
-# This file is part of the Maeser unit test suite.
-
-# Maeser is free software: you can redistribute it and/or modify it under the terms of
-# the GNU Lesser General Public License as published by the Free Software Foundation,
-# either version 3 of the License, or (at your option) any later version.
-
-# Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-# PURPOSE. See the GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License along with
-# Maeser. If not, see <https://www.gnu.org/licenses/>.
-
 SHELL := /bin/bash
 IN_ENV := source .venv/bin/activate;
 

--- a/.github/compare_versions.py
+++ b/.github/compare_versions.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser GitHub actions.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 import sys
 from packaging import version
 

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,4 @@
 # Minimal makefile for development setup
-# 2025 Gohaun Manley, Ayden Bales
-
-# This file is part of the Maeser unit test suite.
-
-# Maeser is free software: you can redistribute it and/or modify it under the terms of
-# the GNU Lesser General Public License as published by the Free Software Foundation,
-# either version 3 of the License, or (at your option) any later version.
-
-# Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-# PURPOSE. See the GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License along with
-# Maeser. If not, see <https://www.gnu.org/licenses/>.
 
 .PHONY: setup test testVerbose clean_venv
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ An understanding of langchain and langgraph is necessary for customizing the app
 
 Maeser is licensed on the LGPL version 3 or later: you can redistribute it and/or modify it under the terms of
 the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+either version 3 of the License, or (at your option) any later version. Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ An understanding of langchain and langgraph is necessary for customizing the app
 - `sphinx_docs` contains sphinx related code and various documentation files.
 - `tests` contains unit test files for the application's source code. 
 
-This package is licensed on the LGPL version 3 or later.
-See [COPYING.LESSER.md](COPYING.LESSER.md) and [COPYING.md](COPYING.md) for details.
+Maeser is licensed on the LGPL version 3 or later: you can redistribute it and/or modify it under the terms of
+the GNU Lesser General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
 
-Other resources may be licensed under different compatible licenses, such as the [MIT License](https://opensource.org/license/mit) (Bootstrap Icons), [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/legalcode) (normalize.css), or [CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/legalcode.en) (images and vector stores).
+Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.
+
+See [COPYING.LESSER.md](COPYING.LESSER.md) and [COPYING.md](COPYING.md) for more details on the GNU Lesser General Public License. Other resources may be licensed under different compatible licenses, such as the [MIT License](https://opensource.org/license/mit) (Bootstrap Icons), [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/legalcode) (normalize.css), or [CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/legalcode.en) (images and vector stores).

--- a/dynamic_implementations/config.py
+++ b/dynamic_implementations/config.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser usage example.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 import yaml
 import os
 

--- a/dynamic_implementations/config_example.yaml
+++ b/dynamic_implementations/config_example.yaml
@@ -1,18 +1,3 @@
-# © 2024
-
-# This file is part of the Maeser usage example.
-
-# Maeser is free software: you can redistribute it and/or modify it under the terms of
-# the GNU Lesser General Public License as published by the Free Software Foundation,
-# either version 3 of the License, or (at your option) any later version.
-
-# Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-# PURPOSE. See the GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License along with
-# Maeser. If not, see <https://www.gnu.org/licenses/>.
-
 ### API keys are required for OpenAI and GitHub integrations ###
 
 api_keys:

--- a/dynamic_implementations/generate_response.py
+++ b/dynamic_implementations/generate_response.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser usage example.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 import os
 
 # Import Maeser components

--- a/example/config_example.py
+++ b/example/config_example.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser usage example.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 import yaml
 import os
 

--- a/example/config_example.yaml
+++ b/example/config_example.yaml
@@ -1,18 +1,3 @@
-# © 2024
-
-# This file is part of the Maeser usage example.
-
-# Maeser is free software: you can redistribute it and/or modify it under the terms of
-# the GNU Lesser General Public License as published by the Free Software Foundation,
-# either version 3 of the License, or (at your option) any later version.
-
-# Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-# PURPOSE. See the GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License along with
-# Maeser. If not, see <https://www.gnu.org/licenses/>.
-
 ### API keys are required for OpenAI and GitHub integrations ###
 
 api_keys:

--- a/example/create_byu_vectorstore.py
+++ b/example/create_byu_vectorstore.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser usage example.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 # Extract the text from the Brigham Young University Wikipedia page
 
 import wikipediaapi

--- a/example/create_maeser_vectorstore.py
+++ b/example/create_maeser_vectorstore.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser usage example.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 # Extract the text from the Karl G. Maeser Wikipedia page
 
 import wikipediaapi

--- a/example/flask_multigroup_example.py
+++ b/example/flask_multigroup_example.py
@@ -1,19 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser usage example.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
 from config_example import (
     LOG_SOURCE_PATH, OPENAI_API_KEY, VEC_STORE_PATH, CHAT_HISTORY_PATH, LLM_MODEL_NAME
 )

--- a/example/flask_multigroup_user_mangement_example.py
+++ b/example/flask_multigroup_user_mangement_example.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser usage example.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 from config_example import (
     LOG_SOURCE_PATH, OPENAI_API_KEY, USERS_DB_PATH, 
     VEC_STORE_PATH, MAX_REQUESTS, RATE_LIMIT_INTERVAL, 

--- a/example/flask_pipeline_example.py
+++ b/example/flask_pipeline_example.py
@@ -1,19 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser usage example.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
 from config_example import (
     LOG_SOURCE_PATH, OPENAI_API_KEY, VEC_STORE_PATH, CHAT_HISTORY_PATH, LLM_MODEL_NAME
 )

--- a/example/flask_pipeline_user_mangement_example.py
+++ b/example/flask_pipeline_user_mangement_example.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser usage example.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 from config_example import (
     LOG_SOURCE_PATH, OPENAI_API_KEY, USERS_DB_PATH, 
     VEC_STORE_PATH, MAX_REQUESTS, RATE_LIMIT_INTERVAL, 

--- a/example/terminal_multigroup_example.py
+++ b/example/terminal_multigroup_example.py
@@ -1,19 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser usage example.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
 from config_example import (
     LOG_SOURCE_PATH, OPENAI_API_KEY, VEC_STORE_PATH, CHAT_HISTORY_PATH, LLM_MODEL_NAME
 )

--- a/example/terminal_pipeline_example.py
+++ b/example/terminal_pipeline_example.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser usage example.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 from maeser.chat.chat_logs import ChatLogsManager
 from maeser.chat.chat_session_manager import ChatSessionManager
 from config_example import (

--- a/maeser/__init__.py
+++ b/maeser/__init__.py
@@ -12,21 +12,6 @@ The package is organized as follows:
           in the chat application.
 - `render`: This module contains classes and functions for rendering the user
           interface of the chat application.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from . import chat

--- a/maeser/blueprints.py
+++ b/maeser/blueprints.py
@@ -4,21 +4,6 @@ Blueprint definitions for the Maeser application.
 This module sets up the Flask blueprint and associated routes for the Maeser
 application. It includes route handlers for chat interfaces, user management,
 feedback, and training functionalities.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from flask import Blueprint, Flask

--- a/maeser/chat/__init__.py
+++ b/maeser/chat/__init__.py
@@ -5,21 +5,6 @@ This package contains the following subpackages and modules:
 
 - `chat_logs`: This module provides functionality for managing chat logs.
 - `chat_session_manager`: This module provides functionality for managing chat sessions.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from . import chat_logs

--- a/maeser/chat/chat_logs.py
+++ b/maeser/chat/chat_logs.py
@@ -1,21 +1,6 @@
 """
 Module for managing chat logs, including logging and retrieving chat history,
 feedback, and training data.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from maeser.user_manager import UserManager, User

--- a/maeser/chat/chat_session_manager.py
+++ b/maeser/chat/chat_session_manager.py
@@ -1,20 +1,5 @@
 """
 Module for managing chat sessions and interactions with multiple chat interfaces.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from maeser.chat.chat_logs import BaseChatLogsManager

--- a/maeser/controllers/__init__.py
+++ b/maeser/controllers/__init__.py
@@ -1,21 +1,6 @@
 """
 This is the controllers subpackage for the Maeser package. It contains the
 controllers for the different parts of the application.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from . import (

--- a/maeser/controllers/chat_api.py
+++ b/maeser/controllers/chat_api.py
@@ -1,21 +1,6 @@
 """Module for handling chat API requests.
 
 This module contains the controller function for managing chat sessions and processing incoming messages.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from maeser.chat.chat_session_manager import ChatSessionManager

--- a/maeser/controllers/chat_interface.py
+++ b/maeser/controllers/chat_interface.py
@@ -1,21 +1,6 @@
 """Module for handling chat interface rendering.
 
 This module contains a function to render the chat interface template with relevant data.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from flask import render_template

--- a/maeser/controllers/chat_logs_overview.py
+++ b/maeser/controllers/chat_logs_overview.py
@@ -2,21 +2,6 @@
 This module contains the controller function for rendering the chat logs overview page.
 
 It handles fetching log files, applying filters, and calculating aggregate data such as total tokens and cost.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from maeser.chat.chat_session_manager import ChatSessionManager

--- a/maeser/controllers/common/__init__.py
+++ b/maeser/controllers/common/__init__.py
@@ -2,21 +2,6 @@
 This is the common subpackage for controllers subpackage in the Maeser package.
 This package contains commonly used functions and classes that are used across
 multiple controllers.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from . import decorators

--- a/maeser/controllers/common/decorators.py
+++ b/maeser/controllers/common/decorators.py
@@ -1,21 +1,6 @@
 """
 This module contains decorators for rate limiting and admin access control
 in a Flask application.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from functools import wraps

--- a/maeser/controllers/conversation_history_api.py
+++ b/maeser/controllers/conversation_history_api.py
@@ -4,21 +4,6 @@ Module for handling conversation history retrieval in a Flask API.
 This module defines a controller function that retrieves the conversation history
 for a given session and branch. The conversation history is processed to handle
 system messages by applying HTML response formatting.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from flask import jsonify, request

--- a/maeser/controllers/display_chat_log.py
+++ b/maeser/controllers/display_chat_log.py
@@ -3,21 +3,6 @@ This module contains functions for processing and rendering chat logs.
 
 It includes functions to process messages, get the log file template, and display
 the content of a specified log file.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from maeser.chat.chat_session_manager import ChatSessionManager

--- a/maeser/controllers/feedback_api.py
+++ b/maeser/controllers/feedback_api.py
@@ -4,21 +4,6 @@ This module defines a controller function that processes feedback
 for messages. The feedback includes information such as the branch,
 session ID, message, whether it is a like or dislike, and the index
 of the message.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from maeser.chat.chat_session_manager import ChatSessionManager

--- a/maeser/controllers/feedback_form_get.py
+++ b/maeser/controllers/feedback_form_get.py
@@ -1,21 +1,6 @@
 """Module for handling feedback form display.
 
 This module contains the controller function to render the feedback form template.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from flask import render_template

--- a/maeser/controllers/feedback_form_post.py
+++ b/maeser/controllers/feedback_form_post.py
@@ -1,20 +1,5 @@
 """
 Module for handling feedback form submissions.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from maeser.chat.chat_session_manager import ChatSessionManager

--- a/maeser/controllers/login_api.py
+++ b/maeser/controllers/login_api.py
@@ -1,20 +1,5 @@
 """
 Module for handling login and GitHub OAuth2 authorization controllers.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from flask import render_template, redirect, url_for, request, session

--- a/maeser/controllers/logout.py
+++ b/maeser/controllers/logout.py
@@ -1,20 +1,5 @@
 """
 Logout controller for handling user logouts and session cleanup.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from flask_login import logout_user

--- a/maeser/controllers/manage_users_view.py
+++ b/maeser/controllers/manage_users_view.py
@@ -1,20 +1,5 @@
 """
 This module contains the controller for rendering the user management page.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from flask import render_template

--- a/maeser/controllers/new_session_api.py
+++ b/maeser/controllers/new_session_api.py
@@ -3,21 +3,6 @@ This module handles API requests for creating new chat sessions.
 
 It uses the ChatSessionManager to manage session creation and optionally integrates
 with user management through Flask-Login's current_user.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from maeser.chat.chat_session_manager import ChatSessionManager

--- a/maeser/controllers/remaining_requests_api.py
+++ b/maeser/controllers/remaining_requests_api.py
@@ -1,20 +1,5 @@
 """
 This module provides a controller for fetching the remaining requests for a user.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 def controller(auth_manager, current_user):

--- a/maeser/controllers/training.py
+++ b/maeser/controllers/training.py
@@ -1,20 +1,5 @@
 """
 This module contains the controller function to display the training form.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from flask import render_template

--- a/maeser/controllers/training_post.py
+++ b/maeser/controllers/training_post.py
@@ -1,21 +1,6 @@
 """
 This module contains functions to save training data and handle controller
 requests in a Flask application.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from maeser.chat.chat_session_manager import ChatSessionManager

--- a/maeser/controllers/user_management_api.py
+++ b/maeser/controllers/user_management_api.py
@@ -4,21 +4,6 @@ User management API controller.
 This module provides an API endpoint for managing users, including listing users,
 toggling admin and banned statuses, updating request counts, removing users from
 the cache, fetching users, listing cleanable users, and cleaning the cache.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from typing import Any

--- a/maeser/data/static/chat.js
+++ b/maeser/data/static/chat.js
@@ -1,20 +1,3 @@
-/*
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-*/
-
 // Initialize variables
 let session = "";
 let chat_branch = "";

--- a/maeser/data/static/feedback.js
+++ b/maeser/data/static/feedback.js
@@ -1,20 +1,3 @@
-/*
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-*/
-
 function goBack() {
     window.history.back();
 }

--- a/maeser/data/static/styles.css
+++ b/maeser/data/static/styles.css
@@ -1,20 +1,3 @@
-/*
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-*/
-
 @import "normalize.css";
 @import "bootstrap-icons/font/bootstrap-icons.min.css";
 

--- a/maeser/data/static/user-management.js
+++ b/maeser/data/static/user-management.js
@@ -1,20 +1,3 @@
-/*
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-*/
-
 // Wait for the DOM to be fully loaded before executing the script
 document.addEventListener('DOMContentLoaded', function() {
     // Constants

--- a/maeser/data/templates/chat_interface.html
+++ b/maeser/data/templates/chat_interface.html
@@ -19,23 +19,6 @@
         </script>
     </head>
     <body>
-        <!--
-        © 2024
-    
-        This file is part of Maeser.
-    
-        Maeser is free software: you can redistribute it and/or modify it under the terms of
-        the GNU Lesser General Public License as published by the Free Software Foundation,
-        either version 3 of the License, or (at your option) any later version.
-    
-        Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-        without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-        PURPOSE. See the GNU Lesser General Public License for more details.
-    
-        You should have received a copy of the GNU Lesser General Public License along with
-        Maeser. If not, see <https://www.gnu.org/licenses/>.
-        -->
-    
         <div id="main-app">
             <header>
                 <div class="header-wrapper">

--- a/maeser/data/templates/chat_logs_overview.html
+++ b/maeser/data/templates/chat_logs_overview.html
@@ -12,23 +12,6 @@
     <link rel="stylesheet" href="{{ url_for('maeser.static', filename='styles.css') }}">
 </head>
 <body>
-    <!--
-    © 2024
-
-    This file is part of Maeser.
-
-    Maeser is free software: you can redistribute it and/or modify it under the terms of
-    the GNU Lesser General Public License as published by the Free Software Foundation,
-    either version 3 of the License, or (at your option) any later version.
-
-    Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-    PURPOSE. See the GNU Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public License along with
-    Maeser. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
     <header>
         <div class="header-wrapper">
             <div id="logo-tab">

--- a/maeser/data/templates/display_chat_log.html
+++ b/maeser/data/templates/display_chat_log.html
@@ -12,23 +12,6 @@
     <link rel="stylesheet" href="{{ url_for('maeser.static', filename='styles.css') }}">
 </head>
 <body>
-    <!--
-    © 2024
-
-    This file is part of Maeser.
-
-    Maeser is free software: you can redistribute it and/or modify it under the terms of
-    the GNU Lesser General Public License as published by the Free Software Foundation,
-    either version 3 of the License, or (at your option) any later version.
-
-    Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-    PURPOSE. See the GNU Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public License along with
-    Maeser. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
     <b>Name: {{real_name}}</b>
     <b>User Authentication: {{user_name}}</b>
     <b>Time: {{time}}</b>

--- a/maeser/data/templates/feedback_form.html
+++ b/maeser/data/templates/feedback_form.html
@@ -12,23 +12,6 @@
     <link rel="stylesheet" href="{{ url_for('maeser.static', filename='styles.css') }}">
 </head>
 <body>
-    <!--
-    © 2024
-
-    This file is part of Maeser.
-
-    Maeser is free software: you can redistribute it and/or modify it under the terms of
-    the GNU Lesser General Public License as published by the Free Software Foundation,
-    either version 3 of the License, or (at your option) any later version.
-
-    Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-    PURPOSE. See the GNU Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public License along with
-    Maeser. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
     <header>
         <div class="header-wrapper">
             <div id="logo-tab">

--- a/maeser/data/templates/login.html
+++ b/maeser/data/templates/login.html
@@ -12,23 +12,6 @@
     <link rel="stylesheet" href="{{ url_for('maeser.static', filename='styles.css') }}">
 </head>
 <body>
-    <!--
-    © 2024
-
-    This file is part of Maeser.
-
-    Maeser is free software: you can redistribute it and/or modify it under the terms of
-    the GNU Lesser General Public License as published by the Free Software Foundation,
-    either version 3 of the License, or (at your option) any later version.
-
-    Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-    PURPOSE. See the GNU Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public License along with
-    Maeser. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
     <main>
         <div class="form-login">
             {% if main_logo_login %}

--- a/maeser/data/templates/training.html
+++ b/maeser/data/templates/training.html
@@ -12,23 +12,6 @@
     <link rel="stylesheet" href="{{ url_for('maeser.static', filename='styles.css') }}">
 </head>
 <body>
-    <!--
-    © 2024
-
-    This file is part of Maeser.
-
-    Maeser is free software: you can redistribute it and/or modify it under the terms of
-    the GNU Lesser General Public License as published by the Free Software Foundation,
-    either version 3 of the License, or (at your option) any later version.
-
-    Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-    PURPOSE. See the GNU Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public License along with
-    Maeser. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
     <header>
         <div class="header-wrapper">
             <div id="logo-tab">

--- a/maeser/data/templates/user_management.html
+++ b/maeser/data/templates/user_management.html
@@ -14,23 +14,6 @@
     <script src="{{ url_for('maeser.static', filename='user-management.js') }}"></script>
 </head>
 <body>
-    <!--
-    © 2024
-
-    This file is part of Maeser.
-
-    Maeser is free software: you can redistribute it and/or modify it under the terms of
-    the GNU Lesser General Public License as published by the Free Software Foundation,
-    either version 3 of the License, or (at your option) any later version.
-
-    Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-    PURPOSE. See the GNU Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public License along with
-    Maeser. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
     <header>
         <div class="header-wrapper">
             <div id="logo-tab">

--- a/maeser/graphs/pipeline_rag.py
+++ b/maeser/graphs/pipeline_rag.py
@@ -1,20 +1,5 @@
 """
 Module for creating a simple retrieval-augmented generation (RAG) graph using LangChain.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 from langchain_core.documents.base import Document
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder

--- a/maeser/graphs/simple_rag.py
+++ b/maeser/graphs/simple_rag.py
@@ -1,20 +1,5 @@
 """
 Module for creating a simple retrieval-augmented generation (RAG) graph using LangChain.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from langchain_core.documents.base import Document

--- a/maeser/render.py
+++ b/maeser/render.py
@@ -4,21 +4,6 @@ Markdown response conversion module. Intended for use with LLM output.
 This module provides a utility function to easily customize HTML layouts and convert markdown 
 responses to HTML with additional processing, such as adding target="_blank" to anchor tags 
 and adjusting paths for images.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import markdown

--- a/maeser/user_manager.py
+++ b/maeser/user_manager.py
@@ -3,21 +3,6 @@ User management module for authentication and authorization.
 
 This module provides classes and utilities for managing users,
 including authentication methods, database operations, and request tracking.
-
-© 2024
-
-This file is part of Maeser.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
 """
 
 

--- a/sphinx-docs/Makefile
+++ b/sphinx-docs/Makefile
@@ -1,18 +1,4 @@
 # Minimal makefile for Sphinx documentation
-# © 2024
-
-# This file is part of the Maeser unit test suite.
-
-# Maeser is free software: you can redistribute it and/or modify it under the terms of
-# the GNU Lesser General Public License as published by the Free Software Foundation,
-# either version 3 of the License, or (at your option) any later version.
-
-# Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-# PURPOSE. See the GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License along with
-# Maeser. If not, see <https://www.gnu.org/licenses/>.
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.

--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -4,21 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# © 2024
-
-# This file is part of the Maeser unit test suite.
-
-# Maeser is free software: you can redistribute it and/or modify it under the terms of
-# the GNU Lesser General Public License as published by the Free Software Foundation,
-# either version 3 of the License, or (at your option) any later version.
-
-# Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-# PURPOSE. See the GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License along with
-# Maeser. If not, see <https://www.gnu.org/licenses/>.
-
 
 # -- Path setup --------------------------------------------------------------
 

--- a/tests/chat/test_chat_logs.py
+++ b/tests/chat/test_chat_logs.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser unit test suite.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 import pytest
 import os
 import yaml

--- a/tests/chat/test_chat_session_manager.py
+++ b/tests/chat/test_chat_session_manager.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser unit test suite.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 import pytest
 from unittest.mock import MagicMock, patch
 from maeser.chat.chat_session_manager import ChatSessionManager

--- a/tests/test_user_manager.py
+++ b/tests/test_user_manager.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser unit test suite.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 from pathlib import Path
 import pytest
 from maeser.user_manager import UserManager, GithubAuthenticator

--- a/web_client/config.py
+++ b/web_client/config.py
@@ -1,20 +1,3 @@
-"""
-© 2024
-
-This file is part of the Maeser usage example.
-
-Maeser is free software: you can redistribute it and/or modify it under the terms of
-the GNU Lesser General Public License as published by the Free Software Foundation,
-either version 3 of the License, or (at your option) any later version.
-
-Maeser is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along with
-Maeser. If not, see <https://www.gnu.org/licenses/>.
-"""
-
 import yaml
 import os
 


### PR DESCRIPTION
This PR removes the copyright disclaimer from all files in the Maeser repository and updates the copyright disclaimer on the top-level readme. Once this PR is pulled, a solution to automatically add SPDX license headers to the project's files will be implemented (in a separate PR).