### PR TITLE
Fix Duplicate GitHub Action checks

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,6 @@
 name: documentation
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 
 permissions:
   contents: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: Run Python tests
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     name: Run tests

--- a/.github/workflows/ruff_lint.yml
+++ b/.github/workflows/ruff_lint.yml
@@ -1,6 +1,6 @@
 name: Ruff Linting
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   lint:


### PR DESCRIPTION
I noticed several GitHub actions were being run twice every time a Pull Request was submitted. Upon investigating, it appears that these checks were set up to trigger on every push and pull request. Since nothing changes between a pull request and a push, the action was being running twice consecutively. This PR rectifies this behavior by removing the redundant check on PR for those actions that were looking for both pushes and PRs.