### PR TITLE
Rename App_Manager to AppManager

### DIFF
--- a/example/flask_multigroup_example.py
+++ b/example/flask_multigroup_example.py
@@ -41,9 +41,9 @@ from flask import Flask
 
 base_app = Flask(__name__)
 
-from maeser.blueprints import App_Manager
+from maeser.blueprints import AppManager
 
-app_manager = App_Manager(
+app_manager = AppManager(
     app=base_app,
     app_name="Maeser Test App -- NO USER MANAGER",
     flask_secret_key="secret",

--- a/example/flask_multigroup_user_mangement_example.py
+++ b/example/flask_multigroup_user_mangement_example.py
@@ -76,11 +76,11 @@ from flask import Flask
 
 base_app = Flask(__name__)
 
-from maeser.blueprints import App_Manager
+from maeser.blueprints import AppManager
 
 # Create the App_Manager class
 
-app_manager = App_Manager(
+app_manager = AppManager(
     app=base_app,
     app_name="Maeser Test App",
     flask_secret_key="secret",

--- a/example/flask_multigroup_user_mangement_example.py
+++ b/example/flask_multigroup_user_mangement_example.py
@@ -78,7 +78,7 @@ base_app = Flask(__name__)
 
 from maeser.blueprints import AppManager
 
-# Create the App_Manager class
+# Create the AppManager class
 
 app_manager = AppManager(
     app=base_app,

--- a/example/flask_pipeline_example.py
+++ b/example/flask_pipeline_example.py
@@ -49,9 +49,9 @@ from flask import Flask
 
 base_app = Flask(__name__)
 
-from maeser.blueprints import App_Manager
+from maeser.blueprints import AppManager
 
-app_manager = App_Manager(
+app_manager = AppManager(
     app=base_app,
     app_name="Maeser Test App -- NO USER MANAGER",
     flask_secret_key="secret",

--- a/example/flask_pipeline_user_mangement_example.py
+++ b/example/flask_pipeline_user_mangement_example.py
@@ -81,10 +81,10 @@ from flask import Flask
 
 base_app = Flask(__name__)
 
-from maeser.blueprints import App_Manager
+from maeser.blueprints import AppManager
 
 # Create the App_Manager class
-app_manager = App_Manager(
+app_manager = AppManager(
     app=base_app,
     app_name="Maeser Test App",
     flask_secret_key="secret",

--- a/example/flask_pipeline_user_mangement_example.py
+++ b/example/flask_pipeline_user_mangement_example.py
@@ -83,7 +83,7 @@ base_app = Flask(__name__)
 
 from maeser.blueprints import AppManager
 
-# Create the App_Manager class
+# Create the AppManager class
 app_manager = AppManager(
     app=base_app,
     app_name="Maeser Test App",

--- a/maeser/blueprints.py
+++ b/maeser/blueprints.py
@@ -38,7 +38,7 @@ from .controllers import (
 )
 
 
-class App_Manager:
+class AppManager:
     """
     Manages the Maeser App and its configurations.
 

--- a/sphinx-docs/development/architecture.md
+++ b/sphinx-docs/development/architecture.md
@@ -1,11 +1,11 @@
 # Architecture Overview
 
-This document provides a detailed walkthrough of Maeser’s core architecture. At the center is the **App_Manager**, which initializes and connects all major modules. Below is a graphical representation of the class hierarchy:
+This document provides a detailed walkthrough of Maeser’s core architecture. At the center is the **AppManager**, which initializes and connects all major modules. Below is a graphical representation of the class hierarchy:
 
 ```{mermaid}
 flowchart LR
   %% Root Flask orchestrator
-  A0["Maeser Flask App"] --> A1["App_Manager"]
+  A0["Maeser Flask App"] --> A1["AppManager"]
 
   %% ChatSessionManager Module
   subgraph ChatModule["ChatSessionManager Module"]
@@ -55,7 +55,7 @@ flowchart LR
 
 ## Core Components
 
-### App_Manager
+### AppManager
 - **File:** `maeser/blueprints.py`  
 - **Role:** Bootstraps and configures the Flask app, registers routes via blueprints, applies theming, and initializes background tasks (e.g., quota refresh). Everything flows through this central orchestrator.
 
@@ -99,7 +99,7 @@ flowchart LR
 
 ## Request Flow Summary
 1. **HTTP Request** arrives at the Flask app.  
-2. **App_Manager** routes the request to the proper controller.  
+2. **AppManager** routes the request to the proper controller.  
 3. **Controllers** interact with **ChatSessionManager** or **UserManager** depending on the endpoint.  
 4. **ChatSessionManager** invokes RAG graphs or logs via **ChatLogsManager** for chat operations.  
 5. **UserManager** authenticates and manages user data for secure endpoints.  

--- a/sphinx-docs/development/flask_example.md
+++ b/sphinx-docs/development/flask_example.md
@@ -251,11 +251,11 @@ from flask import Flask
 
 base_app = Flask(__name__)
 
-from maeser.blueprints import App_Manager
+from maeser.blueprints import AppManager
 
-# Create the App_Manager class
+# Create the AppManager class
 
-app_manager = App_Manager(
+app_manager = AppManager(
     app=base_app,
     app_name="Maeser Test App",
     flask_secret_key="secret",

--- a/sphinx-docs/development/libraries.md
+++ b/sphinx-docs/development/libraries.md
@@ -53,7 +53,7 @@ Understanding these dependencies empowers you to extend Maeser, debug quickly, a
 
 ### [Flask](https://flask.palletsprojects.com/en/stable/quickstart/)
 - **Role:** Lightweight WSGI framework for web endpoints
-- **Use case:** Hosts chat UI, auth flows, admin dashboards—bootstrapped by `App_Manager`.
+- **Use case:** Hosts chat UI, auth flows, admin dashboards—bootstrapped by `AppManager`.
 
 ### [Jinja2](https://jinja.palletsprojects.com/en/stable/)
 - **Role:** HTML templating engine

--- a/sphinx-docs/user-setup/user_setup.md
+++ b/sphinx-docs/user-setup/user_setup.md
@@ -129,7 +129,7 @@ For quick, command‑line access without a web browser, **Run one of the termina
 ## Customizing Your Experience
 
 - **Add Your Own Content:** Follow the guide at [**Embedding New Content**](../development/embedding.md) to embed your own documents as vectorstores. 
-- **Customize the Web Interface:** Change the parameters of the **App_Manager** in your Flask script to change the color and icons used by the web interface. (For more information on the App_Manager class, refer to the source code documentation on [blueprints](../autodoc/maeser/maeser.blueprints.rst)).
+- **Customize the Web Interface:** Change the parameters of the **AppManager** in your Flask script to change the color and icons used by the web interface. (For more information on the AppManager class, refer to the source code documentation on [blueprints](../autodoc/maeser/maeser.blueprints.rst)).
 - **Add Authentication:** Download one of the `flask_*_user_management_example.py` scripts to configure GitHub or LDAP authentication. See [**User Management Setup**](../development/flask_example.md#user-management-setup) in the **Maeser Example (with Flask & User Management)** documentation page for instructions on how to configure authentication.
 
 ---


### PR DESCRIPTION
`App_Manager` is the class that handles configuring the Maeser app with Flask blueprints. The name of this class doesn't follow the standard naming convention used in Python and in the rest of the project where class names are PascalCase without underscores. This PR fixes this discrepancy by replacing all references of App_Manager with AppManager, both in the code and in the documentation. Quick tests of example/flask_multigroup_example.py and example/flask_pipeline_example.py indicate that everything is working after this adjustment.