### PR TITLE
pyproject.toml Updates

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish PyPI Package
 
 on: 
   push:
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Pypi credentials
+    - name: PyPI credentials
       run: |  
         python -m pip install --upgrade pip
         pip install poetry

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ PYTEST := $(VENV)/bin/pytest
 setup: $(VENV)/bin/activate
 	$(PIP) install poetry
 	$(PIP) install langchain
-	$(PIP) install tiktoken
 	$(PIP) install PyMuPDF
 	$(PIP) install pymupdf-stubs
 	$(PIP) install pymupdf4llm

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,9 @@ PYTEST := $(VENV)/bin/pytest
 
 setup: $(VENV)/bin/activate
 	$(PIP) install poetry
-	$(PIP) install langchain
-	$(PIP) install PyMuPDF
-	$(PIP) install pymupdf-stubs
-	$(PIP) install pymupdf4llm
-	$(PIP) install Pillow
-	$(PIP) install discord
 	@echo "Updating poetry lock file if necessary..."
 	$(POETRY) lock
-	$(POETRY) install
+	$(POETRY) install --all-extras
 	$(PIP) install -e .
 	@echo "Maeser setup complete. Running pytests..."
 	. $(VENV)/bin/activate && pytest tests

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -2,3 +2,4 @@ maeser
 flask
 flask-login
 wikipedia-api
+pyinputplus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,13 @@ authors = [
     { name = "Ayden Bales", email = "aydenmb@byu.edu" },
     { name = "Adam Sandland", email = "adam@sandland.org" },
 ]
+license = { text = "LGPL-3.0-or-later" }
+readme = "README.md"
+keywords = [ "maeser", "chatbot", "llm", "AI", "Retrieval Augmented Generation", "RAG", "education" ]
+
+[project.urls]
+repository = "https://github.com/byu-cpe/Maeser"
+documentation = "https://byu-cpe.github.io/Maeser/"
 
 [tool.poetry]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
 license = { text = "LGPL-3.0-or-later" }
 readme = "README.md"
 keywords = [ "maeser", "chatbot", "llm", "AI", "Retrieval Augmented Generation", "RAG", "education" ]
+requires-python = ">=3.10"
 
 # the fields specified in 'dynamic' will be populated from the corresponding fields in the [tool.poetry] sections
 dynamic = [
@@ -53,7 +54,7 @@ classifiers = [
 [tool.poetry.dependencies]
 # Specify where your Python interpreter is located
 # Replace with your Python version if different
-python = "<4.0,>=3.10"
+python = ">=3.10,<4.0"
 
 # Langchain libraries for text processing and embeddings
 langchain = "^0.2.17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ langchain_openai = "^0.1.16"
 langchain-text-splitters = "^0.2.2"
 langgraph = "^0.1.8"
 
+# Tiktoken library used by maeser/graphs/universal_rag.py
+tiktoken = "^0.9.0"
+
 # FAISS for vector stores (CPU version by default, GPU as optional)
 # pip install maeser[gpu] for the GPU variant
 faiss-cpu = "^1.8.0.post1"
@@ -32,8 +35,8 @@ faiss-cpu = "^1.8.0.post1"
 flask = "^3.0.3"
 flask-login = "^0.6.3"
 
-#Ldap3 for alternative authentication purposes
-ldap3 = "^2.9.1" 
+# Ldap3 for alternative authentication purposes
+ldap3 = "^2.9.1"
 
 # Turning markdown into HTML for display
 markdown = "^3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,6 @@ markdown = "^3.6"
 pymdown-extensions = "^10.8.1"
 markdownify = "^0.14.1"
 
-# Unit testing
-ragas = "^0.1.10"
-
 # Configuration
 pyYAML = "^6.0.1"
 
@@ -53,7 +50,11 @@ requests = "^2.32.3"
 
 # Declare your project's development dependencies here
 [tool.poetry.group.dev.dependencies]
+# Pytest for testing Maeser
 pytest = "^8.2"
+
+# Unit testing
+ragas = "^0.1.10"
 
 # Documentation
 sphinx = "^7.2.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
+### Vanilla Python Project Specifications ###
 [project]
 name = "maeser"
 version = "0.2.1"
@@ -16,6 +17,7 @@ dynamic = [ "classifiers" ]
 repository = "https://github.com/byu-cpe/Maeser"
 documentation = "https://byu-cpe.github.io/Maeser/"
 
+### Poetry Project Specifications ###
 [tool.poetry]
 include = [
     "maeser/data/*",
@@ -23,6 +25,7 @@ include = [
     "maeser/data/static/*"
 ]
 
+# Trove classifiers used by PyPI for categorization; see https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ documentation = "https://byu-cpe.github.io/Maeser/"
 include = [
     "maeser/data/*",
     "maeser/data/templates/*",
-    "maeser/data/static/*"
+    "maeser/data/static/*",
 ]
 
 # Trove classifiers used by PyPI for categorization; see https://pypi.org/classifiers/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,12 @@ include = [
 python = "<4.0,>=3.10"
 
 # Langchain libraries for text processing and embeddings
-langchain = "^0.2.8"
-langchain_core = "^0.2.19"
-langchain_community = "^0.2.7"
-langchain_openai = "^0.1.16"
-langchain-text-splitters = "^0.2.2"
-langgraph = "^0.1.8"
+langchain = "^0.2.17"
+langchain_core = "^0.2.43"
+langchain_community = "^0.2.19"
+langchain_openai = "^0.1.25"
+langchain-text-splitters = "^0.2.4"
+langgraph = "^0.1.19"
 
 # Tiktoken library used by maeser/graphs/universal_rag.py
 tiktoken = "^0.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,3 @@ sphinxcontrib-mermaid = "^1.0.0"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-
-# Define extra dependencies
-[tool.poetry.extras]
-gpu = ["faiss-gpu"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ ldap3 = "^2.9.1"
 # Turning markdown into HTML for display
 markdown = "^3.6"
 pymdown-extensions = "^10.8.1"
-markdownify = "^0.13.1"
+markdownify = "^0.14.1"
 
 # Unit testing
 ragas = "^0.1.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,11 @@ license = { text = "LGPL-3.0-or-later" }
 readme = "README.md"
 keywords = [ "maeser", "chatbot", "llm", "AI", "Retrieval Augmented Generation", "RAG", "education" ]
 
-dynamic = [ "classifiers" ] # The classifiers field in [tool.poetry] will populate this field
+# the fields specified in 'dynamic' will be populated from the corresponding fields in the [tool.poetry] sections
+dynamic = [
+    "classifiers",
+    "dependencies",
+]
 
 [project.urls]
 repository = "https://github.com/byu-cpe/Maeser"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# For helpful information on the sections and fields in this file, see https://python-poetry.org/docs/pyproject/
+
 ### Vanilla Python Project Specifications ###
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,13 @@
-[tool.poetry]
+[project]
 name = "maeser"
 version = "0.2.1"
 description = "A package for building RAG chatbot applications for educational contexts."
-authors = ["Carson Bush <hyperdriveguy@byui.edu>", "Blaine Freestone <blainefreestone@gmail.com>"]
+authors = [
+    { name = "Ayden Bales", email = "aydenmb@byu.edu" },
+    { name = "Adam Sandland", email = "adam@sandland.org" },
+]
+
+[tool.poetry]
 include = [
     "maeser/data/*",
     "maeser/data/templates/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,11 @@ pyYAML = "^6.0.1"
 requests = "^2.32.3"
 
 # Declare your project's development dependencies here
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^8.2"
 
 # Documentation
+sphinx = "^7.2.6"
 sphinx_rtd_theme = "^2.0.0"
 myst_parser = "^3.0.1"
 sphinx-book-theme = "^1.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ license = { text = "LGPL-3.0-or-later" }
 readme = "README.md"
 keywords = [ "maeser", "chatbot", "llm", "AI", "Retrieval Augmented Generation", "RAG", "education" ]
 
+dynamic = [ "classifiers" ]
+
 [project.urls]
 repository = "https://github.com/byu-cpe/Maeser"
 documentation = "https://byu-cpe.github.io/Maeser/"
@@ -19,6 +21,21 @@ include = [
     "maeser/data/*",
     "maeser/data/templates/*",
     "maeser/data/static/*"
+]
+
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Environment :: Web Environment",
+    "Framework :: Flask",
+    "Intended Audience :: Education",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Topic :: Communications :: Chat",
+    "Topic :: Education :: Computer Aided Instruction (CAI)",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 
 # Dependencies required by your project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 ### Vanilla Python Project Specifications ###
+
 [project]
 name = "maeser"
 version = "0.2.1"
@@ -18,6 +19,7 @@ repository = "https://github.com/byu-cpe/Maeser"
 documentation = "https://byu-cpe.github.io/Maeser/"
 
 ### Poetry Project Specifications ###
+
 [tool.poetry]
 include = [
     "maeser/data/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,22 @@ dynamic = [
     "dependencies",
 ]
 
+# URLs to be displayed on PyPI
 [project.urls]
 repository = "https://github.com/byu-cpe/Maeser"
 documentation = "https://byu-cpe.github.io/Maeser/"
+
+# Optional dependencies, installed with `pip install maeser[dependency_group]`
+[project.optional-dependencies]
+# For everything in the web_client directory
+web_client = [
+    "PyMuPDF>=1.26.3,<2.0.0",
+    "pymupdf4llm>=0.0.27,<1.0.0",
+]
+# For dynamic_implementations/discord_handler.py
+discord = [
+    "discord.py>=2.5.2,<3.0.0",
+]
 
 ### Poetry Project Specifications ###
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "LGPL-3.0-or-later" }
 readme = "README.md"
 keywords = [ "maeser", "chatbot", "llm", "AI", "Retrieval Augmented Generation", "RAG", "education" ]
 
-dynamic = [ "classifiers" ]
+dynamic = [ "classifiers" ] # The classifiers field in [tool.poetry] will populate this field
 
 [project.urls]
 repository = "https://github.com/byu-cpe/Maeser"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ tiktoken = "^0.9.0"
 # FAISS for vector stores (CPU version by default, GPU as optional)
 # pip install maeser[gpu] for the GPU variant
 faiss-cpu = "^1.8.0.post1"
-# faiss-gpu = { version = "^1.7.2", optional = true }
 
 # Web backend
 flask = "^3.0.3"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -21,7 +21,7 @@ ldap3
 # Turning markdown into HTML for display
 markdown
 pymdown-extensions
-markdownify
+markdownify==0.14.1
 requests
 
 # Unit testing

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,32 +7,32 @@ langchain-text-splitters==0.2.4
 langgraph==0.1.19
 
 # FAISS for vector stores (choose either faiss-cpu or faiss-gpu depending on your setup)
-faiss-cpu
+faiss-cpu==1.8.0.post1
 # faiss-gpu
 faiss-gpu
 
 # Web backend
-flask
-flask-login
+flask==3.0.3
+flask-login==0.6.3
 
 #Caedm Authenticator 
-ldap3
+ldap3==2.9.1
 
 # Turning markdown into HTML for display
-markdown
-pymdown-extensions
+markdown==3.6
+pymdown-extensions==10.8.1
 markdownify==0.14.1
 requests
 
 # Unit testing
-ragas
+ragas==0.1.10
 
 # Documentation
 sphinx
-sphinx_rtd_theme
-myst_parser
-sphinx-book-theme
-sphinxcontrib-mermaid
+sphinx_rtd_theme==2.0.0
+myst_parser==3.0.1
+sphinx-book-theme==1.1.3
+sphinxcontrib-mermaid==1.0.0
 
 # Default logger
 pyYAML

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -26,7 +26,7 @@ requests
 ragas==0.1.10
 
 # Documentation
-sphinx==8.2.3
+sphinx==7.4.7
 sphinx_rtd_theme==2.0.0
 myst_parser==3.0.1
 sphinx-book-theme==1.1.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -26,7 +26,7 @@ requests
 ragas==0.1.10
 
 # Documentation
-sphinx==7.4.7
+sphinx==7.2.6
 sphinx_rtd_theme==2.0.0
 myst_parser==3.0.1
 sphinx-book-theme==1.1.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,6 +6,9 @@ langchain_openai==0.1.25
 langchain-text-splitters==0.2.4
 langgraph==0.1.19
 
+# Tiktoken library used by maeser/graphs/universal_rag.py
+tiktoken==0.9.0
+
 # FAISS for vector stores (choose either faiss-cpu or faiss-gpu depending on your setup)
 faiss-cpu==1.8.0.post1
 
@@ -20,7 +23,12 @@ ldap3==2.9.1
 markdown==3.6
 pymdown-extensions==10.8.1
 markdownify==0.14.1
-requests
+
+# For HTTP requests
+requests==2.32.3
+
+# Pytest for testing Maeser
+pytest==8.2
 
 # Unit testing
 ragas==0.1.10

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -26,14 +26,14 @@ requests
 ragas==0.1.10
 
 # Documentation
-sphinx
+sphinx==8.2.3
 sphinx_rtd_theme==2.0.0
 myst_parser==3.0.1
 sphinx-book-theme==1.1.3
 sphinxcontrib-mermaid==1.0.0
 
 # Default logger
-pyYAML
+pyYAML==6.0.2
 
 # Discord
-discord
+discord==2.3.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,8 +8,6 @@ langgraph==0.1.19
 
 # FAISS for vector stores (choose either faiss-cpu or faiss-gpu depending on your setup)
 faiss-cpu==1.8.0.post1
-# faiss-gpu
-faiss-gpu
 
 # Web backend
 flask==3.0.3

--- a/sphinx-docs/development/architecture.md
+++ b/sphinx-docs/development/architecture.md
@@ -51,7 +51,6 @@ flowchart LR
   A1 --> D0["Jinja2 Render Helpers"]
 
 ```
-> **Note:** If the diagram above is not rendering properly, try switching the page theme from dark to light.
 
 ## Core Components
 


### PR DESCRIPTION
This PR adds major updates to Maeser's pyproject.toml:

- Replaces deprecated sections with up-to-date sections according to the [Poetry documentation](https://python-poetry.org/docs/pyproject/).
- Updates authors
- Adds more details to be pushed to the PyPI package, including license, readme, keywords, GitHub and Documentation URLs, and Trove classifiers
- Adds optional dependency groups for web client and discord handler
- Updates requirements/requirements.txt for use of GitHub Actions

The general setup of the project is the same; however, the documentation will need to be updated with the optional dependency groups and explain how and when to use them. This will be done in a separate PR.