### PR TITLE
Update Copyright Disclaimer Link in Documentation Footer

### DIFF
--- a/sphinx-docs/_static/js/dynamic-footer-disclaimers.js
+++ b/sphinx-docs/_static/js/dynamic-footer-disclaimers.js
@@ -1,14 +1,21 @@
-// This small javascript code replaces the content of the author and copyright sections, allowing hyperlinks to be inserted
+// This script replaces the content of the author and copyright sections, allowing hyperlinks to be inserted
 
-GITHUB_URL = "https://github.com/byu-cpe/Maeser";
+// Get relative link of TOC page
+function get_toc_link(page_name) {
+  toc_links = document.getElementsByClassName("reference internal");
+  target_page = Array.from(toc_links).find(el => el.textContent == page_name);
+  target_href = target_page.getAttribute('href');
+  return `<a href='${target_href}'>${page_name}</a>`
+}
 
-const AUTHOR_CONTENT = 
-    `By the Maeser Team. See the <a href='${GITHUB_URL}/graphs/contributors'>full list of contributors</a> in the GitHub repository.`;
-
-const COPYRIGHT_CONTENT = 
-    `© Copyright 2025. Licensed under the GNU Lesser General Public License v3.0 or later. For more details, see <a href='${GITHUB_URL}/blob/master/COPYING.LESSER.md'>COPYING.LESSER.md</a> and <a href='${GITHUB_URL}/blob/master/COPYING.md'>COPYING.md</a> in the GitHub repository.`;
 
 document.addEventListener("DOMContentLoaded", () => {
+  GITHUB_URL = "https://github.com/byu-cpe/Maeser";
+  const AUTHOR_CONTENT = 
+    `By the Maeser Team. See the <a href='${GITHUB_URL}/graphs/contributors'>full list of contributors</a> in the GitHub repository.`;
+  const COPYRIGHT_CONTENT = 
+    `© Copyright 2025. Licensed under the GNU Lesser General Public License v3.0 or later. For more details, see ${get_toc_link("About the licenses used in the Maeser project")}.`;
+
   const author = document.getElementsByClassName("component-author")[0];
   const copyright = document.getElementsByClassName("copyright")[0];
 


### PR DESCRIPTION
A recent PR changed the footer in the docs by adding links to files on GitHub containing the license used by Maeser. This PR makes a revision to this and instead links to the page "About the licenses used in the Maeser project" in the documentation itself.