### PR TITLE
Revise Auto License Header Paths

### DIFF
--- a/.github/Makefile
+++ b/.github/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 SHELL := /bin/bash
 IN_ENV := source .venv/bin/activate;
 

--- a/.github/compare_versions.py
+++ b/.github/compare_versions.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 import sys
 from packaging import version
 

--- a/.github/prep_readme_links.py
+++ b/.github/prep_readme_links.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 """
 This module prepares the project's readme for publishing to PyPI by replacing all relative repository links to absolute GitHub links.
 The script can be run from the command line or imported into another script.

--- a/.github/print_version.py
+++ b/.github/print_version.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 import pkg_resources  # part of setuptools
 
 version = pkg_resources.require("maeser")[0].version

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -4,6 +4,9 @@ header:
   license:
     content: 'SPDX-License-Identifier: LGPL-3.0-or-later'
 
+  paths:
+    - .github/{**/*.py,**/makefile} 
+
   paths-ignore:
     - 'dist'
     - 'licenses'
@@ -11,7 +14,7 @@ header:
     - 'LICENSE'
     - 'NOTICE'
     - '.licenserc.yaml'
-    - '.github'
+    - '.github/**/*.yml'
     - '.gitignore'
     - '**/*.toml'
     - '**/*.txt'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -5,7 +5,7 @@ header:
     content: 'SPDX-License-Identifier: LGPL-3.0-or-later'
 
   paths:
-    - .github/{**/*.py,**/makefile} 
+    - .github/**/*.py
 
   paths-ignore:
     - 'dist'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -4,24 +4,24 @@ header:
   license:
     content: 'SPDX-License-Identifier: LGPL-3.0-or-later'
 
+  # See "About the licenses used in the Maeser project" for info on which paths fall under the LGPL v3.0+ license
   paths:
+    - maeser
+    - example
+    - tests/**/*.py
     - .github/**/*.py
+    - .github/**/Makefile
+    - sphinx-docs/**/*.py
+    - sphinx-docs/**/Makefile
+    - sphinx-docs/**/*.js
 
   paths-ignore:
-    - 'dist'
-    - 'licenses'
-    - '**/*.md'
-    - 'LICENSE'
-    - 'NOTICE'
-    - '.licenserc.yaml'
-    - '.github/**/*.yml'
-    - '.gitignore'
     - '**/*.toml'
+    - '**/*.md'
     - '**/*.txt'
     - '**/*.json'
     - 'maeser/data/static/bootstrap-icons'
     - 'maeser/data/static/normalize.css'
     - 'example/vectorstores'
-    - 'sphinx-docs'
 
   comment: on-failure

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -4,7 +4,7 @@ header:
   license:
     content: 'SPDX-License-Identifier: LGPL-3.0-or-later'
 
-  # See "About the licenses used in the Maeser project" for info on which paths fall under the LGPL v3.0+ license
+  # See "About the licenses used in the Maeser project" in the documentation for info on which paths fall under the LGPL v3.0+ license
   paths:
     - maeser
     - example

--- a/sphinx-docs/Makefile
+++ b/sphinx-docs/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 # Minimal makefile for Sphinx documentation
 
 # You can set these variables from the command line, and also

--- a/sphinx-docs/_static/js/dynamic-footer-disclaimers.js
+++ b/sphinx-docs/_static/js/dynamic-footer-disclaimers.js
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
 // This small javascript code replaces the content of the author and copyright sections, allowing hyperlinks to be inserted
 
 GITHUB_URL = "https://github.com/byu-cpe/Maeser";

--- a/sphinx-docs/_static/js/mermaid-theme-switch.js
+++ b/sphinx-docs/_static/js/mermaid-theme-switch.js
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
 // This small javascript code fixes Mermaid diagrams not rendering properly in dark or light mode
 document.addEventListener("DOMContentLoaded", () => {
   const theme = document.documentElement.getAttribute("data-theme") === "dark"

--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/sphinx-docs/legal/repository_info.md
+++ b/sphinx-docs/legal/repository_info.md
@@ -52,6 +52,7 @@ File or directory | Type of file(s) | Current license | Acceptable licenses for 
 File or directory | Type of file(s) | Current license | Acceptable licenses for new files in the same family
 ---:|:---:|:---:|:---
 `sphinx-docs/*.py` | Python source | [LGPL v3](LGPL.md)+ | [AGPL v3](AGPL.md)+*, [GPL v3](GPL.md)+*, [LGPL v3](LGPL.md)+, [MIT](MIT.md), [CC0](CC0.md)
+`sphinx-docs/*.js` | JavaScript source | [LGPL v3](LGPL.md)+ | [AGPL v3](AGPL.md)+*, [GPL v3](GPL.md)+*, [LGPL v3](LGPL.md)+, [MIT](MIT.md), [CC0](CC0.md)
 `sphinx-docs/Makefile` | Makefile source | [LGPL v3](LGPL.md)+ | [AGPL v3](AGPL.md)+*, [GPL v3](GPL.md)+*, [LGPL v3](LGPL.md)+, [MIT](MIT.md), [CC0](CC0.md)
 `sphinx-docs/*/*.md` | Markdown source | [CC-BY-SA 4.0](CCBYSA4.md) | [CC-BY-SA 4.0](CCBYSA4.md), [CC0](CC0.md)
 


### PR DESCRIPTION
This PR updates the list of accepted paths used by the SPDX License Header action to be in accordance with the licenses specified in "About the licenses used in the Maeser project" in the documentation.