### PR TITLE
Fix Index Error on Feedback Submission

### DIFF
--- a/maeser/graphs/pipeline_rag.py
+++ b/maeser/graphs/pipeline_rag.py
@@ -244,7 +244,7 @@ def get_pipeline_rag(
             }
         )
         # Update conversation history with the generated answer.
-        return {"messages": messages + [generation]}
+        return {"messages": [generation]}
 
     # Build the state graph.
     graph = StateGraph(_GraphState)

--- a/maeser/graphs/universal_rag.py
+++ b/maeser/graphs/universal_rag.py
@@ -206,10 +206,6 @@ def get_universal_rag(
             }
         )
 
-        # Append result and trim to last 10 messages
-        new_messages = messages + [result]
-        trimmed_messages = new_messages[-10:]
-
         # Log token usage
         def count_tokens(msgs):
             content = ""
@@ -217,10 +213,7 @@ def get_universal_rag(
                 content += getattr(m, "content", str(m))
             return len(_enc.encode(content))
 
-        print(
-            f"📦 Token count for latest 10 messages: {count_tokens(trimmed_messages)}"
-        )
-        return {"messages": trimmed_messages}
+        return {"messages": [result]}
 
     def summarize_chat_history_node(state: _GraphState) -> Dict[str, Any]:
         messages = state.get("messages", [])


### PR DESCRIPTION
This PR fixes an error where submitting feedback (aka liking/disliking a message) caused an index out of range error. This was ocurring because the entire chat history was being added to the list of messages instead of just the last message. This was causing the chat history to duplicate after every walk through the graph, throwing the message indices off. This issue was present in the pipeline rag graph, and a similar issue caused the same error for universal rag. Both of these rag graphs have been corrected.