### PR TITLE
Remove course selection from Discord handler

### DIFF
--- a/dynamic_implementations/config.py
+++ b/dynamic_implementations/config.py
@@ -36,53 +36,53 @@ OPENAI_API_KEY = config.get("api_keys", {}).get("openai_api_key")
 GITHUB_CLIENT_SECRET = config.get("api_keys", {}).get("github_client_secret")
 
 # Course ID
-COURSE_ID = config.get("course_id")
+COURSE_ID: str = config.get("course_id")
 
 # GitHub Auth
-GITHUB_CLIENT_ID = config.get("github", {}).get("github_client_id")
-GITHUB_AUTH_CALLBACK_URI = config.get("github", {}).get("github_callback_uri")
-GITHUB_TIMEOUT = config.get("github", {}).get("timeout", 10)
+GITHUB_CLIENT_ID: str = config.get("github", {}).get("github_client_id")
+GITHUB_AUTH_CALLBACK_URI: str = config.get("github", {}).get("github_callback_uri")
+GITHUB_TIMEOUT: int = config.get("github", {}).get("timeout", 10)
 
 # LDAP3 Auth
-LDAP3_NAME = config.get("ldap3", {}).get("name", "CAEDM")
-LDAP_SERVER_URLS = config.get("ldap3", {}).get("ldap_server_urls", [])
-LDAP_BASE_DN = config.get("ldap3", {}).get("ldap_base_dn")
-LDAP_ATTRIBUTE_NAME = config.get("ldap3", {}).get("attribute_name")
-LDAP_SEARCH_FILTER = config.get("ldap3", {}).get("search_filter")
-LDAP_OBJECT_CLASS = config.get("ldap3", {}).get("object_class")
-LDAP_ATTRIBUTES = config.get("ldap3", {}).get("attributes", [])
-LDAP_CA_CERT_PATH = config.get("ldap3", {}).get("ca_cert_path")
-LDAP_CONNECTION_TIMEOUT = config.get("ldap3", {}).get("connection_timeout", 5)
+LDAP3_NAME: str = config.get("ldap3", {}).get("name", "CAEDM")
+LDAP_SERVER_URLS: list = config.get("ldap3", {}).get("ldap_server_urls", [])
+LDAP_BASE_DN: str = config.get("ldap3", {}).get("ldap_base_dn")
+LDAP_ATTRIBUTE_NAME: str = config.get("ldap3", {}).get("attribute_name")
+LDAP_SEARCH_FILTER: str = config.get("ldap3", {}).get("search_filter")
+LDAP_OBJECT_CLASS: str = config.get("ldap3", {}).get("object_class")
+LDAP_ATTRIBUTES: list = config.get("ldap3", {}).get("attributes", [])
+LDAP_CA_CERT_PATH: str = config.get("ldap3", {}).get("ca_cert_path")
+LDAP_CONNECTION_TIMEOUT: int = config.get("ldap3", {}).get("connection_timeout", 5)
 
 # Rate Limiting
-MAX_REQUESTS = config.get("rate_limit", {}).get("max_requests", 5)
-RATE_LIMIT_INTERVAL = config.get("rate_limit", {}).get(
+MAX_REQUESTS: int = config.get("rate_limit", {}).get("max_requests", 5)
+RATE_LIMIT_INTERVAL: int = config.get("rate_limit", {}).get(
     "rate_limit_interval_seconds", 180
 )
 
 # Logging
-LOG_SOURCE_PATH = config.get("logging", {}).get("log_source_path")
+LOG_SOURCE_PATH: str = config.get("logging", {}).get("log_source_path")
 
 # Vector Store
-VEC_STORE_PATH = config.get("vectorstore", {}).get("vec_store_path")
-VEC_STORE_TYPE = config.get("vectorstore", {}).get("vec_store_type", "faiss")
+VEC_STORE_PATH: str = config.get("vectorstore", {}).get("vec_store_path")
+VEC_STORE_TYPE: str = config.get("vectorstore", {}).get("vec_store_type", "faiss")
 
 # LLM Configuration
-LLM_MODEL_NAME = config.get("llm", {}).get("llm_model_name", "gpt-4o-mini")
-LLM_PROVIDER = config.get("llm", {}).get("llm_provider", "openai")
-LLM_TOKEN_LIMIT = config.get("llm", {}).get("token_limit", 400)
+LLM_MODEL_NAME: str = config.get("llm", {}).get("llm_model_name", "gpt-4o-mini")
+LLM_PROVIDER: str = config.get("llm", {}).get("llm_provider", "openai")
+LLM_TOKEN_LIMIT: int = config.get("llm", {}).get("token_limit", 400)
 
 # Embedding Model
-EMBED_MODEL = config.get("embed", {}).get("embed_model", "text-embedding-3-large")
-EMBED_PROVIDER = config.get("embed", {}).get("embed_provider", "openai")
+EMBED_MODEL: str = config.get("embed", {}).get("embed_model", "text-embedding-3-large")
+EMBED_PROVIDER: str = config.get("embed", {}).get("embed_provider", "openai")
 
 # User Management
-USERS_DB_PATH = config.get("user_management", {}).get("accounts_db_path")
-CHAT_HISTORY_PATH = config.get("user_management", {}).get("chat_history_path")
+USERS_DB_PATH: str = config.get("user_management", {}).get("accounts_db_path")
+CHAT_HISTORY_PATH: str = config.get("user_management", {}).get("chat_history_path")
 
 # Discord
 DISCORD_BOT_TOKEN = config.get("discord", {}).get("discord_token")
 
 # Teams Bot Credentials (Obtain from Azure Bot Service)
-TEAMS_APP_ID = os.getenv("TEAMS_APP_ID", "")
-TEAMS_APP_PASSWORD = os.getenv("TEAMS_APP_PASSWORD", "")
+TEAMS_APP_ID: str = os.getenv("TEAMS_APP_ID", "")
+TEAMS_APP_PASSWORD: str = os.getenv("TEAMS_APP_PASSWORD", "")

--- a/dynamic_implementations/config.py
+++ b/dynamic_implementations/config.py
@@ -32,8 +32,8 @@ def load_config():
 config = load_config()
 
 # API Keys
-OPENAI_API_KEY = config.get("api_keys", {}).get("openai_api_key")
-GITHUB_CLIENT_SECRET = config.get("api_keys", {}).get("github_client_secret")
+OPENAI_API_KEY: str = config.get("api_keys", {}).get("openai_api_key")
+GITHUB_CLIENT_SECRET: str = config.get("api_keys", {}).get("github_client_secret")
 
 # Course ID
 COURSE_ID: str = config.get("course_id")
@@ -81,7 +81,8 @@ USERS_DB_PATH: str = config.get("user_management", {}).get("accounts_db_path")
 CHAT_HISTORY_PATH: str = config.get("user_management", {}).get("chat_history_path")
 
 # Discord
-DISCORD_BOT_TOKEN = config.get("discord", {}).get("discord_token")
+DISCORD_BOT_TOKEN: str = config.get("discord", {}).get("discord_token")
+DISCORD_INTRO: str = config.get("discord", {}).get("intro")
 
 # Teams Bot Credentials (Obtain from Azure Bot Service)
 TEAMS_APP_ID: str = os.getenv("TEAMS_APP_ID", "")

--- a/dynamic_implementations/config.py
+++ b/dynamic_implementations/config.py
@@ -8,71 +8,80 @@ This module is used to locate `config.yaml` and expose its values for use by the
 import yaml
 import os
 
+
 def load_config():
     """Load configuration from YAML file."""
     config_paths = [
-        'dynamic_implementations/config.yaml',
-        'config.yaml',
-        './config.yaml',
+        "dynamic_implementations/config.yaml",
+        "config.yaml",
+        "./config.yaml",
     ]
-    
+
     for path in config_paths:
         if os.path.exists(path):
-            with open(path, 'r') as file:
-                print(f'Using configuration at {path} (Priority {config_paths.index(path)})')
+            with open(path, "r") as file:
+                print(
+                    f"Using configuration at {path} (Priority {config_paths.index(path)})"
+                )
                 return yaml.safe_load(file)
-    
+
     print("Warning: No configuration file found")
     return {}
+
 
 config = load_config()
 
 # API Keys
-OPENAI_API_KEY = config.get('api_keys', {}).get('openai_api_key')
-GITHUB_CLIENT_SECRET = config.get('api_keys', {}).get('github_client_secret')
+OPENAI_API_KEY = config.get("api_keys", {}).get("openai_api_key")
+GITHUB_CLIENT_SECRET = config.get("api_keys", {}).get("github_client_secret")
+
+# Course ID
+COURSE_ID = config.get("course_id")
 
 # GitHub Auth
-GITHUB_CLIENT_ID = config.get('github', {}).get('github_client_id')
-GITHUB_AUTH_CALLBACK_URI = config.get('github', {}).get('github_callback_uri')
-GITHUB_TIMEOUT = config.get('github', {}).get('timeout', 10)
+GITHUB_CLIENT_ID = config.get("github", {}).get("github_client_id")
+GITHUB_AUTH_CALLBACK_URI = config.get("github", {}).get("github_callback_uri")
+GITHUB_TIMEOUT = config.get("github", {}).get("timeout", 10)
 
 # LDAP3 Auth
-LDAP3_NAME = config.get('ldap3', {}).get('name', 'CAEDM')
-LDAP_SERVER_URLS = config.get('ldap3', {}).get('ldap_server_urls', [])
-LDAP_BASE_DN = config.get('ldap3', {}).get('ldap_base_dn')
-LDAP_ATTRIBUTE_NAME = config.get('ldap3', {}).get('attribute_name')
-LDAP_SEARCH_FILTER = config.get('ldap3', {}).get('search_filter')
-LDAP_OBJECT_CLASS = config.get('ldap3', {}).get('object_class')
-LDAP_ATTRIBUTES = config.get('ldap3', {}).get('attributes', [])
-LDAP_CA_CERT_PATH = config.get('ldap3', {}).get('ca_cert_path')
-LDAP_CONNECTION_TIMEOUT = config.get('ldap3', {}).get('connection_timeout', 5)
+LDAP3_NAME = config.get("ldap3", {}).get("name", "CAEDM")
+LDAP_SERVER_URLS = config.get("ldap3", {}).get("ldap_server_urls", [])
+LDAP_BASE_DN = config.get("ldap3", {}).get("ldap_base_dn")
+LDAP_ATTRIBUTE_NAME = config.get("ldap3", {}).get("attribute_name")
+LDAP_SEARCH_FILTER = config.get("ldap3", {}).get("search_filter")
+LDAP_OBJECT_CLASS = config.get("ldap3", {}).get("object_class")
+LDAP_ATTRIBUTES = config.get("ldap3", {}).get("attributes", [])
+LDAP_CA_CERT_PATH = config.get("ldap3", {}).get("ca_cert_path")
+LDAP_CONNECTION_TIMEOUT = config.get("ldap3", {}).get("connection_timeout", 5)
 
 # Rate Limiting
-MAX_REQUESTS = config.get('rate_limit', {}).get('max_requests', 5)
-RATE_LIMIT_INTERVAL = config.get('rate_limit', {}).get('rate_limit_interval_seconds', 180)
+MAX_REQUESTS = config.get("rate_limit", {}).get("max_requests", 5)
+RATE_LIMIT_INTERVAL = config.get("rate_limit", {}).get(
+    "rate_limit_interval_seconds", 180
+)
 
 # Logging
-LOG_SOURCE_PATH = config.get('logging', {}).get('log_source_path')
+LOG_SOURCE_PATH = config.get("logging", {}).get("log_source_path")
 
 # Vector Store
-VEC_STORE_PATH = config.get('vectorstore', {}).get('vec_store_path')
-VEC_STORE_TYPE = config.get('vectorstore', {}).get('vec_store_type', 'faiss')
+VEC_STORE_PATH = config.get("vectorstore", {}).get("vec_store_path")
+VEC_STORE_TYPE = config.get("vectorstore", {}).get("vec_store_type", "faiss")
 
 # LLM Configuration
-LLM_MODEL_NAME = config.get('llm', {}).get('llm_model_name', 'gpt-4o-mini')
-LLM_PROVIDER = config.get('llm', {}).get('llm_provider', 'openai')
-LLM_TOKEN_LIMIT = config.get('llm', {}).get('token_limit', 400)
+LLM_MODEL_NAME = config.get("llm", {}).get("llm_model_name", "gpt-4o-mini")
+LLM_PROVIDER = config.get("llm", {}).get("llm_provider", "openai")
+LLM_TOKEN_LIMIT = config.get("llm", {}).get("token_limit", 400)
 
 # Embedding Model
-EMBED_MODEL = config.get('embed', {}).get('embed_model', 'text-embedding-3-large')
-EMBED_PROVIDER = config.get('embed', {}).get('embed_provider', 'openai')
+EMBED_MODEL = config.get("embed", {}).get("embed_model", "text-embedding-3-large")
+EMBED_PROVIDER = config.get("embed", {}).get("embed_provider", "openai")
 
 # User Management
-USERS_DB_PATH = config.get('user_management', {}).get('accounts_db_path')
-CHAT_HISTORY_PATH = config.get('user_management', {}).get('chat_history_path')
+USERS_DB_PATH = config.get("user_management", {}).get("accounts_db_path")
+CHAT_HISTORY_PATH = config.get("user_management", {}).get("chat_history_path")
 
-# Tokens
-DISCORD_BOT_TOKEN = config.get('discord', {}).get('discord_token')
+# Discord
+DISCORD_BOT_TOKEN = config.get("discord", {}).get("discord_token")
 
 # Teams Bot Credentials (Obtain from Azure Bot Service)
 TEAMS_APP_ID = os.getenv("TEAMS_APP_ID", "")

--- a/dynamic_implementations/config_template.yaml
+++ b/dynamic_implementations/config_template.yaml
@@ -69,7 +69,7 @@ user_management:
 discord:
   discord_token: "..."
   intro: |
-    👋 Hi there!
-    I'm @self, your digital assistant for this course.
+    ## 👋 Hi there! I'm @self
+    I'm your digital assistant for this course!
     I have access to the course textbook and materials, so I can help you with explanations, examples, and guidance whenever you need it.
     Let's get started! Just send me a DM by clicking my name 👉 @self 👈

--- a/dynamic_implementations/config_template.yaml
+++ b/dynamic_implementations/config_template.yaml
@@ -68,3 +68,8 @@ user_management:
 
 discord:
   discord_token: "..."
+  intro: |
+    👋 Hi there!
+    I'm @self, your digital assistant for this course.
+    I have access to the course textbook and materials, so I can help you with explanations, examples, and guidance whenever you need it.
+    Let's get started! Just send me a DM by clicking my name 👉 @self 👈

--- a/dynamic_implementations/config_template.yaml
+++ b/dynamic_implementations/config_template.yaml
@@ -68,6 +68,10 @@ user_management:
 
 discord:
   discord_token: "..."
+
+  # The introduction message your chatbot should send in your server.
+  # All instances of "@self" will be replaced with a mention to the discord bot
+  # (e.g. "@BotName")
   intro: |
     ## 👋 Hi there! I'm @self
     I'm your digital assistant for this course!

--- a/dynamic_implementations/config_template.yaml
+++ b/dynamic_implementations/config_template.yaml
@@ -7,47 +7,47 @@
 ### API keys are required for OpenAI and GitHub integrations ###
 
 api_keys:
-  openai_api_key: '...'
-  github_client_secret: '...'
+  openai_api_key: "..."
+  github_client_secret: "..."
 
+### The course to which the chatbot will be assigned ##
+
+course_id: "cs121"
 
 ### Other application configurations ###
 
 ### Github Auth ###
 
 github:
-  github_client_id: '...'
-  github_callback_uri: 'http://localhost:3002/login/github_callback'
+  github_client_id: "..."
+  github_callback_uri: "http://localhost:3002/login/github_callback"
   timeout: 10
 
 ### LDAP3 Auth ###
 
 ldap3:
-  name: '...'
-  ldap_server_urls: ['...', '...']
-  ldap_base_dn: '...'
-  attribute_name: '...'
-  search_filter: '({attribute_name}={...})'
-  object_class: '...'
-  attributes: ['{attribute_name}', '...', '...']
-  ca_cert_path: '...'
+  name: "..."
+  ldap_server_urls: ["...", "..."]
+  ldap_base_dn: "..."
+  attribute_name: "..."
+  search_filter: "({attribute_name}={...})"
+  object_class: "..."
+  attributes: ["{attribute_name}", "...", "..."]
+  ca_cert_path: "..."
   connection_timeout: 10
 
 rate_limit:
-  max_requests: 5            # The maximum number of requests that a user can have at any given time
-  rate_limit_interval_seconds: 180      # The time interval in seconds that the rate limit is enforced
-
+  max_requests: 5 # The maximum number of requests that a user can have at any given time
+  rate_limit_interval_seconds: 180 # The time interval in seconds that the rate limit is enforced
 
 ### Configure the logging path and vector store path ###
 
 logging:
   log_source_path: dynamic_implementations/chat_logs
-  
 
 vectorstore:
   vec_store_path: dynamic_implementations/bot_data
   vec_store_type: faiss
-
 
 ### Configure the LLM and text embedding models ###
 
@@ -59,7 +59,6 @@ llm:
   llm_model_name: gpt-4o-mini
   llm_provider: openai
   token_limit: 400
-
 
 ### Configure the user management ###
 

--- a/dynamic_implementations/config_template.yaml
+++ b/dynamic_implementations/config_template.yaml
@@ -76,4 +76,4 @@ discord:
     ## 👋 Hi there! I'm @self
     I'm your digital assistant for this course!
     I have access to the course textbook and materials, so I can help you with explanations, examples, and guidance whenever you need it.
-    Let's get started! Just send me a DM by clicking my name 👉 @self 👈
+    **Let's get started!** Just send me a DM by clicking my name 👉 @self 👈

--- a/dynamic_implementations/discord_handler.py
+++ b/dynamic_implementations/discord_handler.py
@@ -4,7 +4,7 @@ import discord
 import os
 import re
 from generate_response import handle_message, get_valid_course_ids, BOT_DATA_PATH
-from config import DISCORD_BOT_TOKEN, COURSE_ID
+from config import COURSE_ID, DISCORD_BOT_TOKEN, DISCORD_INTRO
 import shlex
 
 import maeser.graphs.universal_rag as RAG_VARS
@@ -97,6 +97,10 @@ async def command_say(
     """
     await channel.send(content)
 
+async def command_intro(channel: discord.abc.Messageable) -> None:
+    intro_content: str = DISCORD_INTRO.replace("@self", client.user.mention)
+    await channel.send(intro_content)
+
 
 @client.event
 async def on_ready():
@@ -130,6 +134,8 @@ async def on_message(message: discord.Message):
                         return
                     say_text: str = "\n".join(command_args[1:])
                     await command_say(message.channel, say_text)
+                case "!intro":
+                    await command_intro(message.channel)
 
         return
 

--- a/dynamic_implementations/discord_handler.py
+++ b/dynamic_implementations/discord_handler.py
@@ -102,6 +102,8 @@ async def command_intro(channel: discord.abc.Messageable) -> None:
     """Sends the default intro message into **channel**.
 
     This message can be configured in the "discord:intro" field in `config.yaml`.
+    All instances of "@self" in the text will be replaced with a mention to the
+    Discord bot (e.g. "@BotName").
 
     Args:
         channel (discord.abc.Messageable): The channel to send the intro message in.

--- a/dynamic_implementations/discord_handler.py
+++ b/dynamic_implementations/discord_handler.py
@@ -98,6 +98,13 @@ async def command_say(
     await channel.send(content)
 
 async def command_intro(channel: discord.abc.Messageable) -> None:
+    """Sends the default intro message into **channel**.
+    
+    This message can be configured in the "discord:intro" field in `config.yaml`.
+
+    Args:
+        channel (discord.abc.Messageable): The channel to send the intro message in.
+    """
     intro_content: str = DISCORD_INTRO.replace("@self", client.user.mention)
     await channel.send(intro_content)
 

--- a/dynamic_implementations/discord_handler.py
+++ b/dynamic_implementations/discord_handler.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 import discord
-import asyncio
 import os
 import re
 from generate_response import handle_message, get_valid_course_ids, BOT_DATA_PATH
-from config import DISCORD_BOT_TOKEN
+from config import DISCORD_BOT_TOKEN, COURSE_ID
+
 import maeser.graphs.universal_rag as RAG_VARS
 
 # Setup intents
@@ -16,25 +16,22 @@ intents.dm_messages = True
 
 client = discord.Client(intents=intents)
 
-# Session tracking
-discord_user_course_ids = {}
-awaiting_course_id_users = set()
-
 
 # Helper: Extract figure references like "1_page3_fig2"
 def extract_figures_from_text(text):
     # Finds "Figure 13.2" and extracts just "13.2"
-    pattern = r'Figure (\d+\.\d+)'
+    pattern = r"Figure (\d+\.\d+)"
     return re.findall(pattern, text)
 
-def split_string(text:str, max_length=1999):
+
+def split_string(text: str, max_length=1999):
     chunks = []
     while len(text) > max_length:
         # Try to split at the last newline before max_length
-        split_index = text.rfind('\n', 0, max_length)
+        split_index = text.rfind("\n", 0, max_length)
         if split_index == -1:
             # Try to split at the last space before max_length
-            split_index = text.rfind(' ', 0, max_length)
+            split_index = text.rfind(" ", 0, max_length)
         if split_index == -1:
             # No good split point; force split
             split_index = max_length
@@ -52,93 +49,54 @@ def split_string(text:str, max_length=1999):
 async def on_ready():
     print(f"✅ Discord Bot connected as {client.user}")
 
+
 @client.event
 async def on_message(message: discord.Message):
-    if message.author.bot:
+    if message.author.bot or not isinstance(message.channel, discord.DMChannel):
         return
 
     user_id = str(message.author.id)
     msg_text = message.content.strip()
 
-    # -- START SESSION HANDLER --
-    if msg_text.lower().startswith("!start"):
-        if user_id in awaiting_course_id_users:
-            await message.channel.send("You are already starting a session. Please provide your course ID or wait for timeout.")
-            return
-
-        await message.channel.send("🧑‍🏫 Please enter your course ID:")
-        awaiting_course_id_users.add(user_id)
-
-        def check(m: discord.Message):
-            return m.author == message.author and m.channel == message.channel and m.content.strip()
-
-        try:
-            reply_message: discord.Message = await client.wait_for("message", check=check, timeout=60)
-            course_id = reply_message.content.strip()
-            valid_courses = get_valid_course_ids()
-
-            while course_id not in valid_courses:
-                await message.channel.send(
-                    f"❌ Invalid course ID. Available options: {', '.join(valid_courses)}\n"
-                    f"🧑‍🏫 Please enter your course ID:"
-                )
-                reply_message = await client.wait_for("message", check=check, timeout=60)
-                course_id = reply_message.content.strip()
-                valid_courses = get_valid_course_ids()
-
-            discord_user_course_ids[user_id] = course_id
-            await message.channel.send(f"✅ Session started for course `{course_id}`! Send your question.")
-
-        except asyncio.TimeoutError:
-            await message.channel.send("⏱️ Timeout: You didn’t reply in time. Try `!start` again.")
-        except Exception as e:
-            await message.channel.send(f"❌ Error starting session: {e}")
-        finally:
-            awaiting_course_id_users.discard(user_id)
-        return
-
-    # Ignore input while waiting for course ID
-    if user_id in awaiting_course_id_users:
-        return
-
     # -- MESSAGE PROCESSING --
-    if user_id in discord_user_course_ids:
-        course_id = discord_user_course_ids[user_id]
-        async with message.channel.typing():
+    async with message.channel.typing():
+        try:
+            reply = handle_message(user_id, COURSE_ID, msg_text)
+            # Send text reply
+            if len(reply) > 1999:
+                chunks = split_string(reply)
+                for chunk in chunks:
+                    await message.channel.send(chunk)
+            else:
+                await message.channel.send(reply)
+
             try:
-                reply = handle_message(user_id, course_id, msg_text)
-                # Send text reply
-                if(len(reply)>1999):
-                    chunks = split_string(reply)
-                    for chunk in chunks:
-                        await message.channel.send(f"🤖 {chunk}")
-                else:   
-                    await message.channel.send(f"🤖 {reply}")
+                # Extract and send figures if referenced
 
-                try:
-                    # Extract and send figures if referenced
+                figure_dir = (
+                    f"{BOT_DATA_PATH}/{COURSE_ID}/{RAG_VARS.recommended_topics[0]}"
+                )
+                figure_names = extract_figures_from_text(reply)
+                files = []
+                for fig in figure_names:
+                    image_path = os.path.join(figure_dir, f"{fig}.png")
+                    if os.path.exists(image_path):
+                        files.append(discord.File(image_path, filename=f"{fig}.png"))
+                    else:
+                        print(f"[WARN] Figure not found: {image_path}")
 
-                    figure_dir = f"{BOT_DATA_PATH}/{course_id}/{RAG_VARS.recommended_topics[0]}"
-                    figure_names = extract_figures_from_text(reply)
-                    files = []
-                    for fig in figure_names:
-                        image_path = os.path.join(figure_dir, f"{fig}.png")
-                        if os.path.exists(image_path):
-                            files.append(discord.File(image_path, filename=f"{fig}.png"))
-                        else:
-                            print(f"[WARN] Figure not found: {image_path}")
+                if files:
+                    await message.channel.send(files=files)
+            except Exception:
+                print("❌ There was an issue sending figures.")
 
-                    if files:
-                        await message.channel.send(files=files)
-                except Exception:
-                    print("❌ There was an issue sending figures.")
+        except Exception as e:
+            await message.channel.send(f"❌ Error: {e}")
 
-            except Exception as e:
-                await message.channel.send(f"❌ Error: {e}")
-    else:
-        await message.channel.send("❗ Please start a session first using `!start`.")
 
-# Run the bot
-client.run(DISCORD_BOT_TOKEN)
+if __name__ == "__main__":
+    if COURSE_ID not in get_valid_course_ids():
+        print(f"ERROR: Course ID {COURSE_ID} not a valid course ID.")
+        exit(1)
 
-client.start()
+    client.run(DISCORD_BOT_TOKEN)

--- a/dynamic_implementations/discord_handler.py
+++ b/dynamic_implementations/discord_handler.py
@@ -97,9 +97,10 @@ async def command_say(
     """
     await channel.send(content)
 
+
 async def command_intro(channel: discord.abc.Messageable) -> None:
     """Sends the default intro message into **channel**.
-    
+
     This message can be configured in the "discord:intro" field in `config.yaml`.
 
     Args:

--- a/dynamic_implementations/discord_handler.py
+++ b/dynamic_implementations/discord_handler.py
@@ -112,6 +112,27 @@ async def command_intro(channel: discord.abc.Messageable) -> None:
     await channel.send(intro_content)
 
 
+async def run_admin_command(message: discord.Message, command_args: list[str]) -> None:
+    channel = message.channel
+    argc: int = len(command_args)
+    match command_args[0]:
+        case "!say":
+            if argc < 2:
+                await channel.send(
+                    "Usage: `!say [CONTENT]`\n"
+                    'Use quotes around CONTENT (e.g. `!say "Hello World!"`)\n'
+                    "Additional arguments will be sent on a new line."
+                )
+                return
+            say_text: str = "\n".join(command_args[1:])
+            await command_say(channel, say_text)
+            await message.delete()
+
+        case "!intro":
+            await command_intro(channel)
+            await message.delete()
+
+
 @client.event
 async def on_ready():
     print(f"✅ Discord Bot connected as {client.user}")
@@ -129,37 +150,23 @@ async def on_message(message: discord.Message):
         return
 
     # Only run admin commands if message is not a DM
-    if not isinstance(message.channel, discord.DMChannel):
+    if not isinstance(channel, discord.DMChannel):
         if is_admin_message(message):
             command_args = shlex.split(msg_text)
-            argc: int = len(command_args)
-            match command_args[0]:
-                case "!say":
-                    if argc < 2:
-                        await channel.send(
-                            "Usage: `!say [CONTENT]`\n"
-                            'Use quotes around CONTENT (e.g. `!say "Hello World!"`)\n'
-                            "Additional arguments will sent on a new line."
-                        )
-                        return
-                    say_text: str = "\n".join(command_args[1:])
-                    await command_say(message.channel, say_text)
-                case "!intro":
-                    await command_intro(message.channel)
-
+            await run_admin_command(message, command_args)
         return
 
     # -- MESSAGE PROCESSING --
-    async with message.channel.typing():
+    async with channel.typing():
         try:
             reply = handle_message(user_id, COURSE_ID, msg_text)
             # Send text reply
             if len(reply) > 1999:
                 chunks = split_string(reply)
                 for chunk in chunks:
-                    await message.channel.send(chunk)
+                    await channel.send(chunk)
             else:
-                await message.channel.send(reply)
+                await channel.send(reply)
 
             try:
                 # Extract and send figures if referenced
@@ -177,12 +184,12 @@ async def on_message(message: discord.Message):
                         print(f"[WARN] Figure not found: {image_path}")
 
                 if files:
-                    await message.channel.send(files=files)
+                    await channel.send(files=files)
             except Exception:
                 print("❌ There was an issue sending figures.")
 
         except Exception as e:
-            await message.channel.send(f"❌ Error: {e}")
+            await channel.send(f"❌ Error: {e}")
 
 
 if __name__ == "__main__":

--- a/dynamic_implementations/discord_handler.py
+++ b/dynamic_implementations/discord_handler.py
@@ -5,6 +5,7 @@ import os
 import re
 from generate_response import handle_message, get_valid_course_ids, BOT_DATA_PATH
 from config import DISCORD_BOT_TOKEN, COURSE_ID
+import shlex
 
 import maeser.graphs.universal_rag as RAG_VARS
 
@@ -18,13 +19,37 @@ client = discord.Client(intents=intents)
 
 
 # Helper: Extract figure references like "1_page3_fig2"
-def extract_figures_from_text(text):
+def extract_figures_from_text(text: str) -> list[str]:
+    """Finds all references to figures in **text** and returns a list of figure IDs.
+
+    The reference to the figure should be formated like "Figure X.X".
+    Only "X.X" (the figure ID) will be extracted and added to the resulting list.
+
+    Args:
+        text (str): The text containing figure references.
+
+    Returns:
+        list[str]: A list of figure IDs.
+    """
     # Finds "Figure 13.2" and extracts just "13.2"
     pattern = r"Figure (\d+\.\d+)"
     return re.findall(pattern, text)
 
 
-def split_string(text: str, max_length=1999):
+def split_string(text: str, max_length=1999) -> list[str]:
+    """Splits one strings into multiple strings so that all resultant chunks are shorter
+    than **max_length**.
+
+    Checks for a semantically clean place to split the text first (e.g. at a whitespace).
+    If a clean place to split is not found, force-splits at **max_length**.
+
+    Args:
+        text (str): The text to split.
+        max_length (int, optional): The maximum length any chunk can be after splitting. Defaults to 1999.
+
+    Returns:
+        list[str]: The list of text chunks that make up the original **text**.
+    """
     chunks = []
     while len(text) > max_length:
         # Try to split at the last newline before max_length
@@ -45,6 +70,34 @@ def split_string(text: str, max_length=1999):
     return chunks
 
 
+def is_admin_message(message: discord.Message) -> bool:
+    """Checks to see if a message was sent by a channel administrator.
+
+    Args:
+        message (discord.Message): The message to check administrator privileges for.
+
+    Returns:
+        bool: True if the message sender is an administrator for the channel the message was sent in.
+    """
+    return (
+        message.guild is not None
+        and message.channel.permissions_for(message.author).administrator
+    )
+
+
+async def command_say(
+    channel: discord.abc.Messageable,
+    content: str,
+) -> None:
+    """Say **content** in **channel**.
+
+    Args:
+        channel (discord.abc.Messageable): The channel to send the message in.
+        content (str): The content of the message.
+    """
+    await channel.send(content)
+
+
 @client.event
 async def on_ready():
     print(f"✅ Discord Bot connected as {client.user}")
@@ -52,11 +105,33 @@ async def on_ready():
 
 @client.event
 async def on_message(message: discord.Message):
-    if message.author.bot or not isinstance(message.channel, discord.DMChannel):
-        return
-
+    # Get data from message
     user_id = str(message.author.id)
     msg_text = message.content.strip()
+    channel = message.channel
+
+    # Ignore if message is from bot or if message is blank
+    if message.author.bot or len(msg_text) == 0:
+        return
+
+    # Only run admin commands if message is not a DM
+    if not isinstance(message.channel, discord.DMChannel):
+        if is_admin_message(message):
+            command_args = shlex.split(msg_text)
+            argc: int = len(command_args)
+            match command_args[0]:
+                case "!say":
+                    if argc < 2:
+                        await channel.send(
+                            "Usage: `!say [CONTENT]`\n"
+                            'Use quotes around CONTENT (e.g. `!say "Hello World!"`)\n'
+                            "Additional arguments will sent on a new line."
+                        )
+                        return
+                    say_text: str = "\n".join(command_args[1:])
+                    await command_say(message.channel, say_text)
+
+        return
 
     # -- MESSAGE PROCESSING --
     async with message.channel.typing():

--- a/dynamic_implementations/discord_handler.py
+++ b/dynamic_implementations/discord_handler.py
@@ -152,8 +152,15 @@ async def on_message(message: discord.Message):
     # Only run admin commands if message is not a DM
     if not isinstance(channel, discord.DMChannel):
         if is_admin_message(message):
-            command_args = shlex.split(msg_text)
-            await run_admin_command(message, command_args)
+            msg_args = shlex.split(
+                msg_text
+            )  # Gets list of args as if msg_text was a terminal command
+
+            # Bot must be mentioned first
+            # and message must contain a command (not just a bot mention)
+            if msg_args[0] == client.user.mention and len(msg_args) > 1:
+                command_args = msg_args[1:]  # remove chatbot mention
+                await run_admin_command(message, command_args)
         return
 
     # -- MESSAGE PROCESSING --

--- a/sphinx-docs/development/discord.md
+++ b/sphinx-docs/development/discord.md
@@ -51,16 +51,16 @@ The information here is optional, but may be helpful if managing multiple bots.
 
 You will want to define a bot **icon** and **username** here. This will be as if you are creating an account for the bot as a person (username and user icon).
 
-Generate your **Discord bot token** by clicking the button labeled `Reset Token`. **Copy this token to `config.yaml`** (in the `discord_token` field).
+Generate your **Discord bot token** by clicking the button labeled "Reset Token". **Copy this token to `config.yaml`** (in the `discord_token` field).
 
-> **Note:** If you ever lose your bot token, you can generate a new token using `Reset Token`. Be sure to update `config.yaml` as well.
+> **Note:** If you ever lose your bot token, you can generate a new token using "Reset Token". Be sure to update `config.yaml` as well.
 
 You will also want to scroll down to the `Privileged Gateway Intents` section and enable the following intents:
 
 - Server Members Intent
 - Message Content Intent
 
-Be sure to save your changes before leaving this page.
+Be sure to **save your changes** before leaving this page.
 
 ---
 
@@ -91,7 +91,7 @@ $ python dynamic_implementations/discord_handler.py
 Using configuration at dynamic_implementations/config.yaml (Priority 0)
 2025-07-30 10:29:44 INFO     discord.client logging in using static token
 2025-07-30 10:29:44 INFO     discord.gateway Shard ID None has connected to Gateway (Session ID: <...>).
-✅ Discord Bot connected as Bot Name#1984
+✅ Discord Bot connected as BotName#1984
 ```
 
 ---
@@ -100,14 +100,49 @@ Using configuration at dynamic_implementations/config.yaml (Priority 0)
 
 **Course models** can be configured and modified using the [**Admin Portal**](./admin_portal.md). By default, the admin portal places these in `dynamic_implementations/bot_data`, which is where the Discord handler also looks for courses.
 
+> **Note:** Your course must have a configured `bot.txt` file to be recognized by the Discord handler. For more information, see [**Required Files and Directory Structure**](./handler_usage.md#required-files-and-directory-structure) and [**bot.txt Syntax**](./handler_usage.md#bottxt-syntax) in the Handler Usage Guide.
+
+---
+
+## Setting up the Discord Bot on a Discord Server
+
+After adding your Discord bot to a discord server (see [**OAuth2**](#oauth2)), your server members can start conversing with your bot by sending it a direct message. The easiest way to present your bot to your server members is by adding it to its own channel on the server and sending an introduction message. To do this, follow the steps below:
+
+1. Create a new text channel on your Discord server (e.g. "#chatbot").
+2. Edit the channel settings by clicking the gear icon next to the channel name or by right clicking the channel and selecting "Edit Channel".
+3. In **Permissions > Advanced Permissions**, make sure "@everyone" is selected in the "Roles/Members" menu, and set "Send Messages" to disabled.
+4. In the "Roles/Members" menu, select your Discord bot (e.g. "BotName#1984"), and set "Send Messages" to enabled. Save and close out of Channel Settings.
+5. In a new channel message, mention your Discord bot (e.g. type "@BotName" and select your bot from the dropdown list), type "!intro", and press enter. The chatbot should respond with a message similar to the following:
+    > **👋 Hi there! I'm `@BotName`**  
+    > I'm your digital assistant for this course!  
+    > I have access to the course textbook and materials, so I can help you with explanations, examples, and guidance whenever you need it.  
+    > **Let's get started!** Just send me a DM by clicking my name 👉 `@BotName` 👈
+
+    You can change the introduction message by modifying the **discord:intro** field in your `config.yaml` file.
+
+You now have a read-only channel on your Discord server that students can use to directly message your Discord bot.
+
+---
+
+## Administrator Commands
+
+Administrator commands control the behavior of your chatbot in your discord server. You can run a command by sending a message into the chat with the following format:
+
+```{code-block} text
+:class: no-copybutton
+@BotName [COMMAND]
+```
+
+Replace "**BotName**" with a mention to your bot (e.g. type "@BotName" and select your bot from the dropdown list), and replace "**\[COMMAND\]**" with one of the following commands:
+
+- **`!intro`**: Sends the default introduction message to the chat. You can change the introduction message by modifying the **discord:intro** field in your `config.yaml` file.
+- **`!say [CONTENT]`**: Sends **CONTENT** into the chat. Be sure your message is surrounded by quotes (e.g. `!say "Hello World."`). Any additional arguments will be sent on a new line.
+
 ---
 
 ## Using Discord
 
-To use your Discord Bot, you may message the bot within a server or directly message it after it has been set up.
+To use your Discord Bot, simply send it a direct message after it has been set up.
 
-- `!start` to begin a new conversation at any time, in any course.
-- `!end` to end a conversation.
-- Type in a course code from any set up courses. If the course you type is unavailable, it will give you a list of courses and prompt you for a course ID again.
-- Ask it questions just like you would in the web application. It's status will update to "typing..." while it is generating a response.
-- The Discord bot has some functionality for pulling figures from the course textbook/resources if figures are present in the course's vector store/dataset folders. However, the figure extraction script used by the Admin Portal is rudimentary and can use much improvement.
+- Ask it questions just like you would with any chatbot interface. It's status will update to "typing..." while it is generating a response.
+- The Discord bot has some functionality for pulling figures from the course textbook/resources if figures are present in the course's vector store/dataset folders. Keep in mind, however, that the figure extraction script used by the [**Admin Portal**](./admin_portal.md) is rudimentary and can use much improvement.

--- a/sphinx-docs/development/discord.md
+++ b/sphinx-docs/development/discord.md
@@ -71,6 +71,7 @@ This is a key part of the setup process. Scroll down to "OAuth2 URL Generator" a
 - Send Messages
 - Send Messages in Threads
 - Send TTS Messages
+- Manage Messages
 - Embed Links
 - Attach Files
 - Read Message History


### PR DESCRIPTION
Previously, starting a conversation with the chatbot in discord required the user to input "!start", followed by the course ID. This PR simplifies the process by restricting the discord bot to only one course and immediately starting a conversation after the user's first message.

One issue to this approach is that the chatbot will always try to interact with a user on any discord channel it has access to. Since this chatbot is meant to have one-on-one conversations with users, the bot will now only respond to a user if it is sent a DM.

In addition to these changes, this PR also adds a few commands that a user can execute if they are a server admin:

- "!say [CONTENT]" makes the chatbot say/echo CONTENT to the channel.
- "!intro" makes the chatbot say an introduction message configured in config.yaml.

This PR updates the documentation to reflect these changes, and also clarifies the importance of configuring `bot.txt` for each course.