### PR TITLE
Update version number to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "maeser"
-version = "0.2.1"
+version = "1.0.0"
 description = "A package for building RAG chatbot applications for educational contexts."
 authors = [
     { name = "Ayden Bales", email = "aydenmb@byu.edu" },


### PR DESCRIPTION
The package has matured much since the last release and is not backwards compatible due to refactorings. For these reasons, 1.0.0 is an appropriate next version number.